### PR TITLE
Fix waitlist status reference and add free_seat test

### DIFF
--- a/dancestudio/backend/app/services/schedule_service.py
+++ b/dancestudio/backend/app/services/schedule_service.py
@@ -19,5 +19,5 @@ def free_seat(db: Session, slot: models.ClassSlot) -> None:
         .first()
     )
     if wait_entry:
-        wait_entry.status = models.waitlist.WaitlistStatus.notified
+        wait_entry.status = models.WaitlistStatus.notified
         db.commit()

--- a/dancestudio/backend/tests/test_schedule.py
+++ b/dancestudio/backend/tests/test_schedule.py
@@ -1,0 +1,26 @@
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+from app.db import models
+from app.services.schedule_service import free_seat
+
+
+def test_free_seat_notifies_waitlisted_user(db_session):
+    direction = models.Direction(name="Test Direction")
+    slot = models.ClassSlot(
+        direction=direction,
+        starts_at=datetime.now(UTC) + timedelta(hours=1),
+        duration_min=60,
+        capacity=10,
+        price_single_visit=Decimal("10.00"),
+    )
+    user = models.User(tg_id=123456)
+    waitlist_entry = models.Waitlist(user=user, slot=slot)
+
+    db_session.add_all([direction, slot, user, waitlist_entry])
+    db_session.commit()
+
+    free_seat(db_session, slot)
+
+    db_session.refresh(waitlist_entry)
+    assert waitlist_entry.status == models.WaitlistStatus.notified


### PR DESCRIPTION
## Summary
- correct the waitlist status reference in the schedule service
- add a unit test ensuring `free_seat` moves the waitlist entry to `notified`

## Testing
- pytest dancestudio/backend/tests/test_schedule.py

------
https://chatgpt.com/codex/tasks/task_e_68d9d36e20d08329b2748485862fc53c