### PR TITLE
Ensure docker setup creates env file automatically

### DIFF
--- a/dancestudio/Makefile
+++ b/dancestudio/Makefile
@@ -1,7 +1,20 @@
-.PHONY: up down migrate seed fmt lint test
+.PHONY: up down migrate seed fmt lint test ensure-env
 
-up:
-	 docker compose -f deploy/docker-compose.yml up -d --build
+ENV_FILE=deploy/env/.env
+ENV_EXAMPLE=deploy/env/.env.example
+
+ensure-env:
+	@if [ ! -f $(ENV_FILE) ]; then \
+		if [ -f $(ENV_EXAMPLE) ]; then \
+			cp $(ENV_EXAMPLE) $(ENV_FILE); \
+			echo "Created $(ENV_FILE) from $(ENV_EXAMPLE). Update secrets as needed."; \
+		else \
+			echo "Missing $(ENV_EXAMPLE). Please create $(ENV_FILE) manually."; \
+			exit 1; \
+		fi; \
+	fi
+up: ensure-env
+docker compose -f deploy/docker-compose.yml up -d --build
 
 down:
 	 docker compose -f deploy/docker-compose.yml down

--- a/dancestudio/docs/README.md
+++ b/dancestudio/docs/README.md
@@ -3,7 +3,7 @@
 ## Запуск
 
 ```bash
-cp deploy/env/.env.example deploy/env/.env
+cp deploy/env/.env.example deploy/env/.env  # необязательно, make up создаст файл автоматически
 make up           # поднять docker-compose
 make migrate      # применить миграции
 make seed         # загрузить тестовые данные


### PR DESCRIPTION
## Summary
- add a Makefile prerequisite that copies deploy/env/.env.example into place when the env file is missing
- document that `make up` now bootstraps the docker environment file automatically

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9d7d339a08329a9cbb5f3ae88be55