### PR TITLE
Fix Alembic migration import and bot parse mode configuration

### DIFF
--- a/dancestudio/backend/app/db/migrations/env.py
+++ b/dancestudio/backend/app/db/migrations/env.py
@@ -1,7 +1,11 @@
 from logging.config import fileConfig
 from sqlalchemy import engine_from_config, pool
 from alembic import context
-from ...config import get_settings
+# Alembic executes this module as a script, which means relative imports that
+# rely on package context (like "...config") fail because there is no parent
+# package information available.  Importing via the absolute package path keeps
+# the configuration accessible regardless of how the module is executed.
+from app.config import get_settings
 from ..base import Base
 from .. import models
 

--- a/dancestudio/bot/app.py
+++ b/dancestudio/bot/app.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 from aiogram import Bot, Dispatcher
+from aiogram.client.default import DefaultBotProperties
 from aiogram.enums import ParseMode
 from aiogram.fsm.storage.memory import MemoryStorage
 from aiogram.types import BotCommand
@@ -13,7 +14,10 @@ logging.basicConfig(level=logging.INFO)
 
 async def main() -> None:
     settings = get_settings()
-    bot = Bot(settings.token, parse_mode=ParseMode.HTML)
+    bot = Bot(
+        settings.token,
+        default=DefaultBotProperties(parse_mode=ParseMode.HTML),
+    )
     dp = Dispatcher(storage=MemoryStorage())
     dp.message.middleware(LoggingMiddleware())
     dp.include_router(menu.router)


### PR DESCRIPTION
## Summary
- replace the Alembic migration config import with an absolute package import to avoid script execution errors
- update the Telegram bot creation to use DefaultBotProperties for parse mode compatibility with aiogram 3.7+

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9dbf13f4c8329923454d8d62a1d09