### PR TITLE
Add python-multipart dependency for form handling

### DIFF
--- a/dancestudio/backend/pyproject.toml
+++ b/dancestudio/backend/pyproject.toml
@@ -19,6 +19,7 @@ python-jose = "^3.3.0"
 redis = "^5.0.1"
 apscheduler = "^3.10.4"
 httpx = "^0.27.0"
+python-multipart = "^0.0.9"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"


### PR DESCRIPTION
## Summary
- add the python-multipart package to the backend dependencies so FastAPI form routes can load

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9ded676bc8329b79393696aeca46e