### PR TITLE
Add admin CRUD management and surface catalog in Telegram bot

### DIFF
--- a/dancestudio/admin-frontend/src/pages/Directions.tsx
+++ b/dancestudio/admin-frontend/src/pages/Directions.tsx
@@ -1,30 +1,152 @@
-import { useQuery } from '@tanstack/react-query'
-import { DataGrid, GridColDef } from '@mui/x-data-grid'
-import { Box, CircularProgress, Alert } from '@mui/material'
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { DataGrid, GridColDef, GridRenderCellParams } from '@mui/x-data-grid'
+import {
+  Box,
+  CircularProgress,
+  Alert,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  FormControlLabel,
+  Switch,
+  Stack
+} from '@mui/material'
 import { apiClient } from '../api/client'
+import { Controller, useForm } from 'react-hook-form'
 
 type Direction = {
   id: number
   name: string
-  description?: string
+  description?: string | null
   is_active: boolean
 }
 
-const columns: GridColDef<Direction>[] = [
-  { field: 'id', headerName: 'ID', width: 90 },
-  { field: 'name', headerName: 'Название', flex: 1 },
-  { field: 'description', headerName: 'Описание', flex: 2 },
-  { field: 'is_active', headerName: 'Активно', type: 'boolean', width: 120 }
-]
+type DirectionFormValues = {
+  name: string
+  description: string
+  is_active: boolean
+}
+
+const defaultValues: DirectionFormValues = {
+  name: '',
+  description: '',
+  is_active: true
+}
 
 const DirectionsPage = () => {
+  const queryClient = useQueryClient()
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [editingDirection, setEditingDirection] = useState<Direction | null>(null)
+
   const { data, isLoading, error } = useQuery({
     queryKey: ['directions'],
     queryFn: async () => {
-      const response = await apiClient.get<Direction[]>('/directions')
+      const response = await apiClient.get<Direction[]>('/directions', {
+        params: { include_inactive: true }
+      })
       return response.data
     }
   })
+
+  const { register, handleSubmit, reset, control, formState } = useForm<DirectionFormValues>({
+    defaultValues
+  })
+
+  const openCreateDialog = () => {
+    setEditingDirection(null)
+    reset(defaultValues)
+    setDialogOpen(true)
+  }
+
+  const openEditDialog = (direction: Direction) => {
+    setEditingDirection(direction)
+    reset({
+      name: direction.name,
+      description: direction.description ?? '',
+      is_active: direction.is_active
+    })
+    setDialogOpen(true)
+  }
+
+  const closeDialog = () => setDialogOpen(false)
+
+  const createMutation = useMutation({
+    mutationFn: async (payload: DirectionFormValues) => {
+      const response = await apiClient.post<Direction>('/directions', {
+        ...payload,
+        description: payload.description.trim() || null
+      })
+      return response.data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['directions'] })
+      closeDialog()
+    }
+  })
+
+  const updateMutation = useMutation({
+    mutationFn: async ({ id, payload }: { id: number; payload: DirectionFormValues }) => {
+      const response = await apiClient.patch<Direction>(`/directions/${id}`, {
+        ...payload,
+        description: payload.description.trim() || null
+      })
+      return response.data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['directions'] })
+      closeDialog()
+    }
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: async (id: number) => {
+      await apiClient.delete(`/directions/${id}`)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['directions'] })
+    }
+  })
+
+  const onSubmit = (values: DirectionFormValues) => {
+    if (editingDirection) {
+      updateMutation.mutate({ id: editingDirection.id, payload: values })
+    } else {
+      createMutation.mutate(values)
+    }
+  }
+
+  const handleDelete = (direction: Direction) => {
+    if (window.confirm(`Удалить направление «${direction.name}»?`)) {
+      deleteMutation.mutate(direction.id)
+    }
+  }
+
+  const columns: GridColDef[] = [
+    { field: 'id', headerName: 'ID', width: 90 },
+    { field: 'name', headerName: 'Название', flex: 1, minWidth: 200 },
+    { field: 'description', headerName: 'Описание', flex: 2, minWidth: 200 },
+    { field: 'is_active', headerName: 'Активно', type: 'boolean', width: 120 },
+    {
+      field: 'actions',
+      headerName: 'Действия',
+      sortable: false,
+      width: 220,
+      renderCell: (params: GridRenderCellParams<Direction>) => (
+        <Stack direction="row" spacing={1}>
+          <Button size="small" onClick={() => openEditDialog(params.row)}>
+            Изменить
+          </Button>
+          <Button size="small" color="error" onClick={() => handleDelete(params.row)}>
+            Удалить
+          </Button>
+        </Stack>
+      )
+    }
+  ]
 
   if (isLoading) {
     return (
@@ -39,9 +161,60 @@ const DirectionsPage = () => {
   }
 
   return (
-    <Box height={400}>
-      <DataGrid rows={data ?? []} columns={columns} disableRowSelectionOnClick />
-    </Box>
+    <>
+      <Box display="flex" justifyContent="flex-end" mb={2}>
+        <Button variant="contained" onClick={openCreateDialog}>
+          Добавить направление
+        </Button>
+      </Box>
+      <Box height={500}>
+        <DataGrid rows={data ?? []} columns={columns} disableRowSelectionOnClick />
+      </Box>
+      <Dialog open={dialogOpen} onClose={closeDialog} maxWidth="sm" fullWidth>
+        <DialogTitle>{editingDirection ? 'Редактирование направления' : 'Новое направление'}</DialogTitle>
+        <DialogContent>
+          <Box component="form" id="direction-form" onSubmit={handleSubmit(onSubmit)}>
+            <TextField
+              label="Название"
+              fullWidth
+              margin="normal"
+              {...register('name', { required: 'Укажите название' })}
+              error={Boolean(formState.errors.name)}
+              helperText={formState.errors.name?.message}
+            />
+            <TextField
+              label="Описание"
+              fullWidth
+              margin="normal"
+              multiline
+              minRows={2}
+              {...register('description')}
+            />
+            <Controller
+              name="is_active"
+              control={control}
+              render={({ field }) => (
+                <FormControlLabel
+                  control={<Switch checked={field.value} onChange={(_, checked) => field.onChange(checked)} />}
+                  label="Активно"
+                />
+              )}
+            />
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={closeDialog}>Отмена</Button>
+          <Button
+            type="submit"
+            form="direction-form"
+            variant="contained"
+            disabled={createMutation.isPending || updateMutation.isPending}
+          >
+            {editingDirection ? 'Сохранить' : 'Добавить'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
   )
 }
 

--- a/dancestudio/admin-frontend/src/pages/Products.tsx
+++ b/dancestudio/admin-frontend/src/pages/Products.tsx
@@ -1,25 +1,65 @@
-import { useQuery } from '@tanstack/react-query'
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { apiClient } from '../api/client'
-import { Alert, CircularProgress, Box } from '@mui/material'
-import { DataGrid, GridColDef } from '@mui/x-data-grid'
+import {
+  Alert,
+  CircularProgress,
+  Box,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Stack,
+  FormControlLabel,
+  Switch
+} from '@mui/material'
+import { DataGrid, GridColDef, GridRenderCellParams } from '@mui/x-data-grid'
+import { useForm, Controller } from 'react-hook-form'
 
 interface Product {
   id: number
   name: string
+  description?: string | null
   price: number
   type: string
   is_active: boolean
+  classes_count?: number | null
+  validity_days?: number | null
+  direction_limit_id?: number | null
 }
 
-const columns: GridColDef<Product>[] = [
-  { field: 'id', headerName: 'ID', width: 80 },
-  { field: 'name', headerName: 'Название', flex: 1 },
-  { field: 'type', headerName: 'Тип', width: 150 },
-  { field: 'price', headerName: 'Цена', width: 150 },
-  { field: 'is_active', headerName: 'Активен', type: 'boolean', width: 120 }
-]
+type ProductFormValues = {
+  name: string
+  type: string
+  description: string
+  price: number
+  classes_count?: number | null
+  validity_days?: number | null
+  direction_limit_id?: number | null
+  is_active: boolean
+}
+
+const defaultValues: ProductFormValues = {
+  name: '',
+  type: '',
+  description: '',
+  price: 0,
+  classes_count: undefined,
+  validity_days: undefined,
+  direction_limit_id: undefined,
+  is_active: true
+}
+
+const normalizeOptionalNumber = (value: number | null | undefined) =>
+  typeof value === 'number' && !Number.isNaN(value) ? value : null
 
 const ProductsPage = () => {
+  const queryClient = useQueryClient()
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [editingProduct, setEditingProduct] = useState<Product | null>(null)
+
   const { data, isLoading, error } = useQuery({
     queryKey: ['products'],
     queryFn: async () => {
@@ -27,6 +67,139 @@ const ProductsPage = () => {
       return response.data
     }
   })
+
+  const { register, handleSubmit, reset, control, formState } = useForm<ProductFormValues>({
+    defaultValues
+  })
+
+  const openCreateDialog = () => {
+    setEditingProduct(null)
+    reset(defaultValues)
+    setDialogOpen(true)
+  }
+
+  const openEditDialog = (product: Product) => {
+    setEditingProduct(product)
+    reset({
+      name: product.name,
+      type: product.type,
+      description: product.description ?? '',
+      price: product.price,
+      classes_count: product.classes_count ?? undefined,
+      validity_days: product.validity_days ?? undefined,
+      direction_limit_id: product.direction_limit_id ?? undefined,
+      is_active: product.is_active
+    })
+    setDialogOpen(true)
+  }
+
+  const closeDialog = () => setDialogOpen(false)
+
+  const createMutation = useMutation({
+    mutationFn: async (payload: ProductFormValues) => {
+      const body = {
+        ...payload,
+        description: payload.description.trim() || null,
+        classes_count: normalizeOptionalNumber(payload.classes_count),
+        validity_days: normalizeOptionalNumber(payload.validity_days),
+        direction_limit_id: normalizeOptionalNumber(payload.direction_limit_id)
+      }
+      const response = await apiClient.post<Product>('/products', body)
+      return response.data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['products'] })
+      closeDialog()
+    }
+  })
+
+  const updateMutation = useMutation({
+    mutationFn: async ({ id, payload }: { id: number; payload: ProductFormValues }) => {
+      const body = {
+        ...payload,
+        description: payload.description.trim() || null,
+        classes_count: normalizeOptionalNumber(payload.classes_count),
+        validity_days: normalizeOptionalNumber(payload.validity_days),
+        direction_limit_id: normalizeOptionalNumber(payload.direction_limit_id)
+      }
+      const response = await apiClient.patch<Product>(`/products/${id}`, body)
+      return response.data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['products'] })
+      closeDialog()
+    }
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: async (id: number) => {
+      await apiClient.delete(`/products/${id}`)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['products'] })
+    }
+  })
+
+  const onSubmit = (values: ProductFormValues) => {
+    if (editingProduct) {
+      updateMutation.mutate({ id: editingProduct.id, payload: values })
+    } else {
+      createMutation.mutate(values)
+    }
+  }
+
+  const handleDelete = (product: Product) => {
+    if (window.confirm(`Удалить продукт «${product.name}»?`)) {
+      deleteMutation.mutate(product.id)
+    }
+  }
+
+  const columns: GridColDef[] = [
+    { field: 'id', headerName: 'ID', width: 80 },
+    { field: 'name', headerName: 'Название', flex: 1, minWidth: 180 },
+    { field: 'type', headerName: 'Тип', width: 140 },
+    {
+      field: 'price',
+      headerName: 'Цена',
+      width: 140,
+      valueFormatter: ({ value }) =>
+        value === undefined || value === null ? '—' : `${Number(value).toLocaleString('ru-RU')} ₽`
+    },
+    {
+      field: 'classes_count',
+      headerName: 'Занятий',
+      width: 120,
+      valueGetter: (params) => params.row.classes_count ?? '—'
+    },
+    {
+      field: 'validity_days',
+      headerName: 'Дней действия',
+      width: 140,
+      valueGetter: (params) => params.row.validity_days ?? '—'
+    },
+    {
+      field: 'is_active',
+      headerName: 'Активен',
+      type: 'boolean',
+      width: 120
+    },
+    {
+      field: 'actions',
+      headerName: 'Действия',
+      sortable: false,
+      width: 220,
+      renderCell: (params: GridRenderCellParams<Product>) => (
+        <Stack direction="row" spacing={1}>
+          <Button size="small" onClick={() => openEditDialog(params.row)}>
+            Изменить
+          </Button>
+          <Button size="small" color="error" onClick={() => handleDelete(params.row)}>
+            Удалить
+          </Button>
+        </Stack>
+      )
+    }
+  ]
 
   if (isLoading) {
     return (
@@ -41,9 +214,99 @@ const ProductsPage = () => {
   }
 
   return (
-    <Box height={400}>
-      <DataGrid rows={data ?? []} columns={columns} disableRowSelectionOnClick />
-    </Box>
+    <>
+      <Box display="flex" justifyContent="flex-end" mb={2}>
+        <Button variant="contained" onClick={openCreateDialog}>
+          Добавить продукт
+        </Button>
+      </Box>
+      <Box height={500}>
+        <DataGrid rows={data ?? []} columns={columns} disableRowSelectionOnClick />
+      </Box>
+      <Dialog open={dialogOpen} onClose={closeDialog} maxWidth="sm" fullWidth>
+        <DialogTitle>{editingProduct ? 'Редактирование продукта' : 'Новый продукт'}</DialogTitle>
+        <DialogContent>
+          <Box component="form" id="product-form" onSubmit={handleSubmit(onSubmit)}>
+            <TextField
+              label="Название"
+              fullWidth
+              margin="normal"
+              {...register('name', { required: 'Укажите название' })}
+              error={Boolean(formState.errors.name)}
+              helperText={formState.errors.name?.message}
+            />
+            <TextField
+              label="Тип"
+              fullWidth
+              margin="normal"
+              {...register('type', { required: 'Укажите тип' })}
+              error={Boolean(formState.errors.type)}
+              helperText={formState.errors.type?.message}
+            />
+            <TextField
+              label="Описание"
+              fullWidth
+              margin="normal"
+              multiline
+              minRows={2}
+              {...register('description')}
+            />
+            <TextField
+              label="Цена"
+              type="number"
+              fullWidth
+              margin="normal"
+              inputProps={{ step: '0.01' }}
+              {...register('price', { required: 'Укажите цену', valueAsNumber: true })}
+              error={Boolean(formState.errors.price)}
+              helperText={formState.errors.price?.message}
+            />
+            <TextField
+              label="Количество занятий"
+              type="number"
+              fullWidth
+              margin="normal"
+              {...register('classes_count', { valueAsNumber: true })}
+            />
+            <TextField
+              label="Срок действия (дни)"
+              type="number"
+              fullWidth
+              margin="normal"
+              {...register('validity_days', { valueAsNumber: true })}
+            />
+            <TextField
+              label="Ограничение по направлению (ID)"
+              type="number"
+              fullWidth
+              margin="normal"
+              {...register('direction_limit_id', { valueAsNumber: true })}
+            />
+            <Controller
+              name="is_active"
+              control={control}
+              render={({ field }) => (
+                <FormControlLabel
+                  control={
+                    <Switch
+                      checked={field.value}
+                      onChange={(_, checked) => field.onChange(checked)}
+                    />
+                  }
+                  label="Активен"
+                />
+              )}
+            />
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={closeDialog}>Отмена</Button>
+          <Button type="submit" form="product-form" variant="contained" disabled={createMutation.isPending || updateMutation.isPending}>
+            {editingProduct ? 'Сохранить' : 'Добавить'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
   )
 }
 

--- a/dancestudio/admin-frontend/src/pages/Schedule.tsx
+++ b/dancestudio/admin-frontend/src/pages/Schedule.tsx
@@ -1,17 +1,77 @@
-import { useQuery } from '@tanstack/react-query'
+import { useMemo, useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { apiClient } from '../api/client'
-import { Alert, CircularProgress, List, ListItem, ListItemText, Box } from '@mui/material'
+import {
+  Alert,
+  CircularProgress,
+  Box,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  FormControlLabel,
+  Switch,
+  MenuItem,
+  Stack
+} from '@mui/material'
+import { DataGrid, GridColDef, GridRenderCellParams } from '@mui/x-data-grid'
 import dayjs from 'dayjs'
+import { Controller, useForm } from 'react-hook-form'
+
+interface Direction {
+  id: number
+  name: string
+}
 
 interface Slot {
   id: number
+  direction_id: number
   starts_at: string
   duration_min: number
   capacity: number
+  price_single_visit: number
+  allow_subscription: boolean
+  status: string
+}
+
+type SlotFormValues = {
+  direction_id: number
+  starts_at: string
+  duration_min: number
+  capacity: number
+  price_single_visit: number
+  allow_subscription: boolean
+  status: string
+}
+
+const slotDefaultValues: SlotFormValues = {
+  direction_id: 0,
+  starts_at: dayjs().startOf('hour').format('YYYY-MM-DDTHH:mm'),
+  duration_min: 60,
+  capacity: 10,
+  price_single_visit: 0,
+  allow_subscription: true,
+  status: 'scheduled'
 }
 
 const SchedulePage = () => {
-  const { data, isLoading, error } = useQuery({
+  const queryClient = useQueryClient()
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [editingSlot, setEditingSlot] = useState<Slot | null>(null)
+
+  const directionsQuery = useQuery({
+    queryKey: ['directions'],
+    queryFn: async () => {
+      const response = await apiClient.get<Direction[]>('/directions', {
+        params: { include_inactive: true }
+      })
+      return response.data
+    }
+  })
+
+  const slotsQuery = useQuery({
     queryKey: ['slots'],
     queryFn: async () => {
       const response = await apiClient.get<Slot[]>('/slots')
@@ -19,7 +79,157 @@ const SchedulePage = () => {
     }
   })
 
-  if (isLoading) {
+  const { register, handleSubmit, reset, control, formState } = useForm<SlotFormValues>({
+    defaultValues: slotDefaultValues
+  })
+
+  const openCreateDialog = () => {
+    if (!directionsQuery.data || directionsQuery.data.length === 0) {
+      return
+    }
+    setEditingSlot(null)
+    const firstDirection = directionsQuery.data[0]
+    reset({
+      ...slotDefaultValues,
+      direction_id: firstDirection.id
+    })
+    setDialogOpen(true)
+  }
+
+  const openEditDialog = (slot: Slot) => {
+    setEditingSlot(slot)
+    reset({
+      direction_id: slot.direction_id,
+      starts_at: dayjs(slot.starts_at).format('YYYY-MM-DDTHH:mm'),
+      duration_min: slot.duration_min,
+      capacity: slot.capacity,
+      price_single_visit: Number(slot.price_single_visit),
+      allow_subscription: slot.allow_subscription,
+      status: slot.status
+    })
+    setDialogOpen(true)
+  }
+
+  const closeDialog = () => setDialogOpen(false)
+
+  const createMutation = useMutation({
+    mutationFn: async (payload: SlotFormValues) => {
+      const response = await apiClient.post<Slot>('/slots', {
+        ...payload,
+        starts_at: dayjs(payload.starts_at).toISOString()
+      })
+      return response.data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['slots'] })
+      closeDialog()
+    }
+  })
+
+  const updateMutation = useMutation({
+    mutationFn: async ({ id, payload }: { id: number; payload: SlotFormValues }) => {
+      const response = await apiClient.patch<Slot>(`/slots/${id}`, {
+        ...payload,
+        starts_at: dayjs(payload.starts_at).toISOString()
+      })
+      return response.data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['slots'] })
+      closeDialog()
+    }
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: async (id: number) => {
+      await apiClient.delete(`/slots/${id}`)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['slots'] })
+    }
+  })
+
+  const onSubmit = (values: SlotFormValues) => {
+    const payload: SlotFormValues = {
+      ...values,
+      price_single_visit: Number(values.price_single_visit)
+    }
+    if (editingSlot) {
+      updateMutation.mutate({ id: editingSlot.id, payload })
+    } else {
+      createMutation.mutate(payload)
+    }
+  }
+
+  const handleDelete = (slot: Slot) => {
+    if (window.confirm('Удалить занятие из расписания?')) {
+      deleteMutation.mutate(slot.id)
+    }
+  }
+
+  const directionsMap = useMemo(() => {
+    const map = new Map<number, string>()
+    directionsQuery.data?.forEach((direction) => {
+      map.set(direction.id, direction.name)
+    })
+    return map
+  }, [directionsQuery.data])
+
+  const columns: GridColDef[] = [
+    { field: 'id', headerName: 'ID', width: 80 },
+    {
+      field: 'direction_id',
+      headerName: 'Направление',
+      flex: 1,
+      minWidth: 180,
+      valueGetter: (params) => directionsMap.get(params.row.direction_id) ?? '—'
+    },
+    {
+      field: 'starts_at',
+      headerName: 'Начало',
+      flex: 1,
+      minWidth: 180,
+      valueFormatter: ({ value }) => dayjs(value as string).format('DD.MM.YYYY HH:mm')
+    },
+    {
+      field: 'duration_min',
+      headerName: 'Длительность, мин',
+      width: 150
+    },
+    { field: 'capacity', headerName: 'Мест', width: 100 },
+    {
+      field: 'price_single_visit',
+      headerName: 'Разовое посещение',
+      width: 180,
+      valueFormatter: ({ value }) =>
+        value === undefined || value === null ? '—' : `${Number(value).toFixed(2)} ₽`
+    },
+    {
+      field: 'allow_subscription',
+      headerName: 'Абонемент',
+      type: 'boolean',
+      width: 140
+    },
+    { field: 'status', headerName: 'Статус', width: 140 },
+    {
+      field: 'actions',
+      headerName: 'Действия',
+      sortable: false,
+      width: 240,
+      renderCell: (params: GridRenderCellParams<Slot>) => (
+        <Stack direction="row" spacing={1}>
+          <Button size="small" onClick={() => openEditDialog(params.row)}>
+            Изменить
+          </Button>
+          <Button size="small" color="error" onClick={() => handleDelete(params.row)}>
+            Удалить
+          </Button>
+        </Stack>
+      )
+    }
+  ]
+
+  if (directionsQuery.isLoading || slotsQuery.isLoading) {
     return (
       <Box display="flex" justifyContent="center" mt={4}>
         <CircularProgress />
@@ -27,21 +237,124 @@ const SchedulePage = () => {
     )
   }
 
-  if (error) {
+  if (directionsQuery.error || slotsQuery.error) {
     return <Alert severity="error">Не удалось загрузить расписание</Alert>
   }
 
+  const directionOptions = directionsQuery.data ?? []
+  const hasDirections = directionOptions.length > 0
+
   return (
-    <List>
-      {data?.map((slot) => (
-        <ListItem key={slot.id} divider>
-          <ListItemText
-            primary={dayjs(slot.starts_at).format('DD.MM.YYYY HH:mm')}
-            secondary={`Длительность: ${slot.duration_min} мин · Мест: ${slot.capacity}`}
-          />
-        </ListItem>
-      ))}
-    </List>
+    <>
+      <Box display="flex" justifyContent="flex-end" mb={2}>
+        <Button variant="contained" onClick={openCreateDialog} disabled={!hasDirections}>
+          Добавить занятие
+        </Button>
+      </Box>
+      {!hasDirections ? (
+        <Alert severity="info">Добавьте направление, чтобы создать расписание.</Alert>
+      ) : (
+        <Box height={500}>
+          <DataGrid rows={slotsQuery.data ?? []} columns={columns} disableRowSelectionOnClick />
+        </Box>
+      )}
+      <Dialog open={dialogOpen} onClose={closeDialog} maxWidth="sm" fullWidth>
+        <DialogTitle>{editingSlot ? 'Редактирование занятия' : 'Новое занятие'}</DialogTitle>
+        <DialogContent>
+          <Box component="form" id="slot-form" onSubmit={handleSubmit(onSubmit)}>
+            <TextField
+              select
+              label="Направление"
+              fullWidth
+              margin="normal"
+              {...register('direction_id', {
+                required: 'Выберите направление',
+                valueAsNumber: true,
+                validate: (value) => value > 0 || 'Выберите направление'
+              })}
+              error={Boolean(formState.errors.direction_id)}
+              helperText={formState.errors.direction_id?.message}
+            >
+              {directionOptions.map((direction) => (
+                <MenuItem key={direction.id} value={direction.id}>
+                  {direction.name}
+                </MenuItem>
+              ))}
+            </TextField>
+            <TextField
+              label="Дата и время начала"
+              type="datetime-local"
+              fullWidth
+              margin="normal"
+              InputLabelProps={{ shrink: true }}
+              {...register('starts_at', { required: 'Укажите дату и время' })}
+              error={Boolean(formState.errors.starts_at)}
+              helperText={formState.errors.starts_at?.message}
+            />
+            <TextField
+              label="Длительность (мин)"
+              type="number"
+              fullWidth
+              margin="normal"
+              {...register('duration_min', { required: 'Укажите длительность', valueAsNumber: true })}
+              error={Boolean(formState.errors.duration_min)}
+              helperText={formState.errors.duration_min?.message}
+            />
+            <TextField
+              label="Количество мест"
+              type="number"
+              fullWidth
+              margin="normal"
+              {...register('capacity', { required: 'Укажите количество мест', valueAsNumber: true })}
+              error={Boolean(formState.errors.capacity)}
+              helperText={formState.errors.capacity?.message}
+            />
+            <TextField
+              label="Стоимость разового посещения"
+              type="number"
+              fullWidth
+              margin="normal"
+              inputProps={{ step: '0.01' }}
+              {...register('price_single_visit', { required: 'Укажите стоимость', valueAsNumber: true })}
+              error={Boolean(formState.errors.price_single_visit)}
+              helperText={formState.errors.price_single_visit?.message}
+            />
+            <Controller
+              name="allow_subscription"
+              control={control}
+              render={({ field }) => (
+                <FormControlLabel
+                  control={<Switch checked={field.value} onChange={(_, checked) => field.onChange(checked)} />}
+                  label="Доступно по абонементу"
+                />
+              )}
+            />
+            <Controller
+              name="status"
+              control={control}
+              render={({ field }) => (
+                <TextField select label="Статус" fullWidth margin="normal" {...field}>
+                  <MenuItem value="scheduled">Запланировано</MenuItem>
+                  <MenuItem value="canceled">Отменено</MenuItem>
+                  <MenuItem value="completed">Проведено</MenuItem>
+                </TextField>
+              )}
+            />
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={closeDialog}>Отмена</Button>
+          <Button
+            type="submit"
+            form="slot-form"
+            variant="contained"
+            disabled={createMutation.isPending || updateMutation.isPending}
+          >
+            {editingSlot ? 'Сохранить' : 'Добавить'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
   )
 }
 

--- a/dancestudio/backend/app/api/routes/directions.py
+++ b/dancestudio/backend/app/api/routes/directions.py
@@ -8,8 +8,14 @@ router = APIRouter(prefix="/directions", tags=["directions"])
 
 
 @router.get("", response_model=list[schemas.Direction])
-def list_directions(db: Session = Depends(get_db)):
-    return db.query(models.Direction).filter_by(is_active=True).all()
+def list_directions(
+    include_inactive: bool = False,
+    db: Session = Depends(get_db),
+):
+    query = db.query(models.Direction)
+    if not include_inactive:
+        query = query.filter_by(is_active=True)
+    return query.all()
 
 
 @router.post("", response_model=schemas.Direction)

--- a/dancestudio/backend/app/api/routes/slots.py
+++ b/dancestudio/backend/app/api/routes/slots.py
@@ -22,7 +22,7 @@ def list_slots(
         query = query.filter(models.ClassSlot.starts_at <= to_dt)
     if direction_id:
         query = query.filter(models.ClassSlot.direction_id == direction_id)
-    return query.all()
+    return query.order_by(models.ClassSlot.starts_at).all()
 
 
 @router.post("", response_model=schemas.ClassSlot)
@@ -67,3 +67,17 @@ def cancel_slot(
     slot.status = models.SlotStatus.canceled
     db.commit()
     return {"status": "canceled"}
+
+
+@router.delete("/{slot_id}")
+def delete_slot(
+    slot_id: int,
+    db: Session = Depends(get_db),
+    _: models.AdminUser = Depends(deps.require_roles("admin")),
+):
+    slot = db.get(models.ClassSlot, slot_id)
+    if not slot:
+        raise HTTPException(status_code=404, detail="Slot not found")
+    db.delete(slot)
+    db.commit()
+    return {"status": "deleted"}

--- a/dancestudio/bot/handlers/menu.py
+++ b/dancestudio/bot/handlers/menu.py
@@ -1,10 +1,27 @@
-from aiogram import Router, F
-from aiogram.types import Message, CallbackQuery
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from aiogram import F, Router
 from aiogram.filters import CommandStart
-from keyboards import main_menu_keyboard
+from aiogram.types import CallbackQuery, Message
+from httpx import HTTPError
+
+from config import get_settings
+from keyboards import (
+    directions_keyboard,
+    main_menu_keyboard,
+    products_keyboard,
+    slots_keyboard,
+)
+from services import fetch_directions, fetch_products, fetch_slots
+from services.api_client import Direction, Slot
 from utils import texts
 
 router = Router()
+_settings = get_settings()
+_timezone = ZoneInfo(_settings.timezone)
 
 
 @router.message(CommandStart())
@@ -23,6 +40,180 @@ async def my_bookings(callback: CallbackQuery) -> None:
     await callback.answer("Функция в разработке", show_alert=True)
 
 
-@router.callback_query(F.data.in_({"book_class", "buy_subscription"}))
-async def not_implemented(callback: CallbackQuery) -> None:
-    await callback.answer("Скоро будет доступно", show_alert=True)
+@router.callback_query(F.data == "buy_subscription")
+async def show_products(callback: CallbackQuery) -> None:
+    try:
+        products = await fetch_products()
+    except HTTPError:
+        await callback.answer(texts.API_ERROR, show_alert=True)
+        return
+
+    if not products:
+        await callback.answer(texts.NO_PRODUCTS, show_alert=True)
+        return
+
+    await callback.message.edit_text(texts.PRODUCTS_PROMPT, reply_markup=products_keyboard(products))
+    await callback.answer()
+
+
+@router.callback_query(F.data.startswith("product:"))
+async def product_details(callback: CallbackQuery) -> None:
+    try:
+        product_id = int(callback.data.split(":", 1)[1])
+    except (IndexError, ValueError):
+        await callback.answer(texts.ITEM_NOT_FOUND, show_alert=True)
+        return
+    try:
+        products = await fetch_products()
+    except HTTPError:
+        await callback.answer(texts.API_ERROR, show_alert=True)
+        return
+
+    product = next((item for item in products if item.get("id") == product_id), None)
+    if not product:
+        await callback.answer(texts.ITEM_NOT_FOUND, show_alert=True)
+        return
+
+    await callback.message.edit_text(texts.product_details(product), reply_markup=products_keyboard(products))
+    await callback.answer()
+
+
+@router.callback_query(F.data == "book_class")
+async def choose_direction(callback: CallbackQuery) -> None:
+    try:
+        directions = await fetch_directions()
+    except HTTPError:
+        await callback.answer(texts.API_ERROR, show_alert=True)
+        return
+
+    if not directions:
+        await callback.answer(texts.NO_DIRECTIONS, show_alert=True)
+        return
+
+    await callback.message.edit_text(texts.DIRECTIONS_PROMPT, reply_markup=directions_keyboard(directions))
+    await callback.answer()
+
+
+def _format_slot_time(slot: Slot) -> tuple[str, str]:
+    starts_at = slot.get("starts_at", "")
+    if starts_at.endswith("Z"):
+        starts_at = starts_at.replace("Z", "+00:00")
+    try:
+        dt = datetime.fromisoformat(starts_at)
+    except ValueError:
+        return "", ""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=ZoneInfo("UTC"))
+    dt_local = dt.astimezone(_timezone)
+    short_label = dt_local.strftime("%d.%m %H:%M")
+    long_label = dt_local.strftime("%d.%m.%Y %H:%M")
+    return short_label, long_label
+
+
+def _direction_title(direction: Direction) -> str:
+    name = direction.get("name", "Направление")
+    return texts.direction_schedule_title(name)
+
+
+@router.callback_query(F.data.startswith("direction:"))
+async def show_direction_schedule(callback: CallbackQuery) -> None:
+    try:
+        direction_id = int(callback.data.split(":", 1)[1])
+    except (IndexError, ValueError):
+        await callback.answer(texts.ITEM_NOT_FOUND, show_alert=True)
+        return
+    try:
+        directions = await fetch_directions()
+        slots = await fetch_slots(direction_id=direction_id)
+    except HTTPError:
+        await callback.answer(texts.API_ERROR, show_alert=True)
+        return
+
+    direction = next((item for item in directions if item.get("id") == direction_id), None)
+    if not direction:
+        await callback.answer(texts.ITEM_NOT_FOUND, show_alert=True)
+        return
+
+    if not slots:
+        await callback.message.edit_text(texts.no_slots(direction.get("name", "")), reply_markup=directions_keyboard(directions))
+        await callback.answer()
+        return
+
+    slot_buttons = []
+    for slot in slots:
+        short_label, _ = _format_slot_time(slot)
+        slot_id = slot.get("id")
+        if not isinstance(slot_id, int):
+            continue
+        if short_label:
+            text = f"{short_label} · {slot.get('duration_min', 0)} мин"
+        else:
+            text = f"Занятие #{slot_id}"
+        slot_buttons.append((slot_id, text))
+
+    if not slot_buttons:
+        await callback.message.edit_text(
+            texts.no_slots(direction.get("name", "")),
+            reply_markup=directions_keyboard(directions),
+        )
+        await callback.answer()
+        return
+
+    await callback.message.edit_text(
+        _direction_title(direction),
+        reply_markup=slots_keyboard(direction_id, slot_buttons),
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data.startswith("slot:"))
+async def show_slot_details(callback: CallbackQuery) -> None:
+    try:
+        _, direction_id_str, slot_id_str = callback.data.split(":", 2)
+        direction_id = int(direction_id_str)
+        slot_id = int(slot_id_str)
+    except (ValueError, IndexError):
+        await callback.answer(texts.ITEM_NOT_FOUND, show_alert=True)
+        return
+
+    try:
+        directions = await fetch_directions()
+        slots = await fetch_slots(direction_id=direction_id)
+    except HTTPError:
+        await callback.answer(texts.API_ERROR, show_alert=True)
+        return
+
+    direction = next((item for item in directions if item.get("id") == direction_id), None)
+    slot = next((item for item in slots if item.get("id") == slot_id), None)
+
+    if not direction or not slot:
+        await callback.answer(texts.ITEM_NOT_FOUND, show_alert=True)
+        return
+
+    _, long_label = _format_slot_time(slot)
+    await callback.answer(
+        texts.slot_details(direction.get("name", ""), slot, long_label),
+        show_alert=True,
+    )
+
+
+@router.callback_query(F.data == "back_to_directions")
+async def back_to_directions(callback: CallbackQuery) -> None:
+    try:
+        directions = await fetch_directions()
+    except HTTPError:
+        await callback.answer(texts.API_ERROR, show_alert=True)
+        return
+
+    if not directions:
+        await callback.answer(texts.NO_DIRECTIONS, show_alert=True)
+        return
+
+    await callback.message.edit_text(texts.DIRECTIONS_PROMPT, reply_markup=directions_keyboard(directions))
+    await callback.answer()
+
+
+@router.callback_query(F.data == "back_main")
+async def back_to_main(callback: CallbackQuery) -> None:
+    await callback.message.edit_text(texts.MAIN_MENU, reply_markup=main_menu_keyboard())
+    await callback.answer()

--- a/dancestudio/bot/keyboards/__init__.py
+++ b/dancestudio/bot/keyboards/__init__.py
@@ -1,2 +1,11 @@
 from .main import main_menu_keyboard
-__all__ = ["main_menu_keyboard"]
+from .products import products_keyboard
+from .directions import directions_keyboard
+from .slots import slots_keyboard
+
+__all__ = [
+    "main_menu_keyboard",
+    "products_keyboard",
+    "directions_keyboard",
+    "slots_keyboard",
+]

--- a/dancestudio/bot/keyboards/directions.py
+++ b/dancestudio/bot/keyboards/directions.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+
+from services.api_client import Direction
+
+
+def directions_keyboard(directions: Sequence[Direction]) -> InlineKeyboardMarkup:
+    keyboard: list[list[InlineKeyboardButton]] = []
+    for direction in directions:
+        direction_id = direction.get("id")
+        if not isinstance(direction_id, int):
+            continue
+        keyboard.append(
+            [InlineKeyboardButton(text=direction.get("name", "Направление"), callback_data=f"direction:{direction_id}")]
+        )
+    keyboard.append([InlineKeyboardButton(text="Назад", callback_data="back_main")])
+    return InlineKeyboardMarkup(inline_keyboard=keyboard)
+
+
+__all__ = ["directions_keyboard"]

--- a/dancestudio/bot/keyboards/products.py
+++ b/dancestudio/bot/keyboards/products.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+
+from services.api_client import Product
+
+
+def _format_price(value: float | int | None) -> str:
+    if value is None:
+        return ""
+    text = f"{float(value):.2f}".rstrip("0").rstrip(".")
+    return text
+
+
+def products_keyboard(products: Sequence[Product]) -> InlineKeyboardMarkup:
+    keyboard: list[list[InlineKeyboardButton]] = []
+    for product in products:
+        product_id = product.get("id")
+        if not isinstance(product_id, int):
+            continue
+        price = _format_price(product.get("price"))
+        title = product.get("name", "Продукт")
+        caption = f"{title}"
+        if price:
+            caption = f"{caption} · {price} ₽"
+        keyboard.append([
+            InlineKeyboardButton(text=caption, callback_data=f"product:{product_id}")
+        ])
+    keyboard.append([InlineKeyboardButton(text="Назад", callback_data="back_main")])
+    return InlineKeyboardMarkup(inline_keyboard=keyboard)
+
+
+__all__ = ["products_keyboard"]

--- a/dancestudio/bot/keyboards/slots.py
+++ b/dancestudio/bot/keyboards/slots.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Iterable, Tuple
+
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+
+
+SlotButton = Tuple[int, str]
+
+
+def slots_keyboard(direction_id: int, slots: Iterable[SlotButton]) -> InlineKeyboardMarkup:
+    keyboard: list[list[InlineKeyboardButton]] = []
+    for slot_id, title in slots:
+        keyboard.append(
+            [InlineKeyboardButton(text=title, callback_data=f"slot:{direction_id}:{slot_id}")]
+        )
+    keyboard.append(
+        [
+            InlineKeyboardButton(text="Назад", callback_data="back_to_directions"),
+            InlineKeyboardButton(text="Главное меню", callback_data="back_main"),
+        ]
+    )
+    return InlineKeyboardMarkup(inline_keyboard=keyboard)
+
+
+__all__ = ["slots_keyboard", "SlotButton"]

--- a/dancestudio/bot/services/__init__.py
+++ b/dancestudio/bot/services/__init__.py
@@ -1,0 +1,7 @@
+from .api_client import fetch_products, fetch_directions, fetch_slots
+
+__all__ = [
+    "fetch_products",
+    "fetch_directions",
+    "fetch_slots",
+]

--- a/dancestudio/bot/services/api_client.py
+++ b/dancestudio/bot/services/api_client.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+import httpx
+
+from config import get_settings
+
+
+class Product(TypedDict, total=False):
+    id: int
+    name: str
+    type: str
+    description: str | None
+    price: float
+    classes_count: int | None
+    validity_days: int | None
+    direction_limit_id: int | None
+    is_active: bool
+
+
+class Direction(TypedDict, total=False):
+    id: int
+    name: str
+    description: str | None
+    is_active: bool
+
+
+class Slot(TypedDict, total=False):
+    id: int
+    direction_id: int
+    starts_at: str
+    duration_min: int
+    capacity: int
+    price_single_visit: float
+    allow_subscription: bool
+    status: str
+
+
+_settings = get_settings()
+
+
+async def _get(path: str, params: dict[str, Any] | None = None) -> Any:
+    async with httpx.AsyncClient(base_url=_settings.api_base_url, timeout=10.0) as client:
+        response = await client.get(path, params=params)
+        response.raise_for_status()
+        return response.json()
+
+
+async def fetch_products(*, active_only: bool = True) -> list[Product]:
+    data = await _get("/products")
+    if active_only:
+        return [product for product in data if product.get("is_active")]
+    return data
+
+
+async def fetch_directions(*, active_only: bool = True) -> list[Direction]:
+    params = {"include_inactive": not active_only}
+    data = await _get("/directions", params=params)
+    if active_only:
+        return [direction for direction in data if direction.get("is_active")]
+    return data
+
+
+async def fetch_slots(*, direction_id: int | None = None) -> list[Slot]:
+    params: dict[str, Any] | None = None
+    if direction_id is not None:
+        params = {"direction_id": direction_id}
+    data = await _get("/slots", params=params)
+    return data
+
+
+__all__ = ["Product", "Direction", "Slot", "fetch_products", "fetch_directions", "fetch_slots"]

--- a/dancestudio/bot/utils/texts.py
+++ b/dancestudio/bot/utils/texts.py
@@ -1,2 +1,68 @@
+from __future__ import annotations
+
+from typing import Mapping
+
 MAIN_MENU = "Что вы хотите сделать?"
 CANCEL_RULES = "Отмена возможна не позднее чем за 24 часа до занятия."
+PRODUCTS_PROMPT = "Выберите доступный абонемент:"  # noqa: E305
+NO_PRODUCTS = "Пока нет доступных абонементов"
+NO_DIRECTIONS = "Пока нет активных направлений"
+API_ERROR = "Не удалось получить данные. Попробуйте позже."
+ITEM_NOT_FOUND = "Элемент не найден. Попробуйте обновить список."
+DIRECTIONS_PROMPT = "Выберите направление:"
+
+
+def _format_price(value: float | int | None) -> str:
+    if value is None:
+        return ""
+    text = f"{float(value):.2f}".rstrip("0").rstrip(".")
+    return f"{text} ₽"
+
+
+def product_details(product: Mapping[str, object]) -> str:
+    name = product.get("name", "Абонемент")
+    lines = [f"<b>{name}</b>"]
+    price = _format_price(product.get("price"))
+    if price:
+        lines.append(f"Стоимость: {price}")
+    description = product.get("description")
+    if isinstance(description, str) and description.strip():
+        lines.append(description.strip())
+    classes_count = product.get("classes_count")
+    if isinstance(classes_count, int) and classes_count > 0:
+        lines.append(f"Занятий: {classes_count}")
+    validity_days = product.get("validity_days")
+    if isinstance(validity_days, int) and validity_days > 0:
+        lines.append(f"Срок действия: {validity_days} дней")
+    return "\n".join(lines)
+
+
+def direction_schedule_title(name: str) -> str:
+    clean_name = name or "Направление"
+    return f"Расписание для «{clean_name}»"
+
+
+def no_slots(name: str) -> str:
+    clean_name = name or "направления"
+    return f"Для «{clean_name}» пока нет занятий."
+
+
+def slot_details(direction_name: str, slot: Mapping[str, object], starts_at: str) -> str:
+    clean_direction = direction_name or "Занятие"
+    duration = slot.get("duration_min", 0)
+    capacity = slot.get("capacity", 0)
+    price = _format_price(slot.get("price_single_visit"))
+    allow_subscription = slot.get("allow_subscription", False)
+    status = slot.get("status", "scheduled")
+
+    lines = [f"{clean_direction}", starts_at]
+    if duration:
+        lines.append(f"Длительность: {duration} мин")
+    if capacity:
+        lines.append(f"Мест: {capacity}")
+    if price:
+        lines.append(f"Разовое посещение: {price}")
+    lines.append("Доступно по абонементу" if allow_subscription else "Без абонемента")
+    if isinstance(status, str) and status != "scheduled":
+        lines.append(f"Статус: {status}")
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary
- enable create/update/delete workflows for products, directions, and schedule entries in the admin UI
- allow fetching inactive directions and deleting slots on the backend to support the new tooling
- surface products, directions, and schedule options in the Telegram bot with dynamic keyboards backed by the API

## Testing
- npm run build
- poetry run pytest *(fails: sqlalchemy.exc.InvalidRequestError: A transaction is already begun on this Session.)*

------
https://chatgpt.com/codex/tasks/task_e_68d9e079115083298f816c61fabfe870