### PR TITLE
Add authentication workflow to admin dashboard

### DIFF
--- a/dancestudio/admin-frontend/src/App.tsx
+++ b/dancestudio/admin-frontend/src/App.tsx
@@ -1,4 +1,17 @@
-import { CssBaseline, ThemeProvider, createTheme, Box, AppBar, Toolbar, Typography, Container, Tabs, Tab } from '@mui/material'
+import {
+  CssBaseline,
+  ThemeProvider,
+  createTheme,
+  Box,
+  AppBar,
+  Toolbar,
+  Typography,
+  Container,
+  Tabs,
+  Tab,
+  CircularProgress,
+  Button
+} from '@mui/material'
 import { useState } from 'react'
 import DashboardPage from './pages/Dashboard'
 import DirectionsPage from './pages/Directions'
@@ -7,6 +20,8 @@ import ProductsPage from './pages/Products'
 import BookingsPage from './pages/Bookings'
 import UsersPage from './pages/Users'
 import SettingsPage from './pages/Settings'
+import LoginPage from './pages/Login'
+import { useAuth } from './auth/AuthContext'
 
 const theme = createTheme()
 
@@ -22,25 +37,57 @@ const tabs = [
 
 function App() {
   const [currentTab, setCurrentTab] = useState(0)
+  const { user, initializing, logout, clearError } = useAuth()
 
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <AppBar position="static">
-        <Toolbar>
-          <Typography variant="h6">Dance Studio Admin</Typography>
-        </Toolbar>
-      </AppBar>
-      <Container maxWidth="lg">
-        <Box mt={4}>
-          <Tabs value={currentTab} onChange={(_, value) => setCurrentTab(value)} variant="scrollable" scrollButtons allowScrollButtonsMobile>
-            {tabs.map((tab, index) => (
-              <Tab key={index} label={tab.label} />
-            ))}
-          </Tabs>
-          <Box mt={4}>{tabs[currentTab].component}</Box>
+      {initializing ? (
+        <Box display="flex" justifyContent="center" alignItems="center" minHeight="100vh">
+          <CircularProgress size={56} />
         </Box>
-      </Container>
+      ) : !user ? (
+        <LoginPage />
+      ) : (
+        <>
+          <AppBar position="static">
+            <Toolbar>
+              <Typography variant="h6" sx={{ flexGrow: 1 }}>
+                Dance Studio Admin
+              </Typography>
+              <Typography variant="body2" sx={{ mr: 3 }}>
+                {user.email}
+              </Typography>
+              <Button
+                color="inherit"
+                onClick={() => {
+                  clearError()
+                  logout()
+                }}
+                sx={{ textTransform: 'none', fontWeight: 500 }}
+              >
+                Выйти
+              </Button>
+            </Toolbar>
+          </AppBar>
+          <Container maxWidth="lg">
+            <Box mt={4}>
+              <Tabs
+                value={currentTab}
+                onChange={(_, value) => setCurrentTab(value)}
+                variant="scrollable"
+                scrollButtons
+                allowScrollButtonsMobile
+              >
+                {tabs.map((tab, index) => (
+                  <Tab key={index} label={tab.label} />
+                ))}
+              </Tabs>
+              <Box mt={4}>{tabs[currentTab].component}</Box>
+            </Box>
+          </Container>
+        </>
+      )}
     </ThemeProvider>
   )
 }

--- a/dancestudio/admin-frontend/src/auth/AuthContext.tsx
+++ b/dancestudio/admin-frontend/src/auth/AuthContext.tsx
@@ -1,0 +1,144 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react'
+import axios from 'axios'
+import { apiClient } from '../api/client'
+
+type AdminUser = {
+  id: number
+  email: string
+  role: string
+}
+
+type AuthContextValue = {
+  user: AdminUser | null
+  token: string | null
+  initializing: boolean
+  error: string | null
+  login: (email: string, password: string) => Promise<void>
+  logout: () => void
+  clearError: () => void
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined)
+
+const readStoredToken = () =>
+  (typeof window !== 'undefined' ? window.localStorage.getItem('admin_token') : null)
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [token, setToken] = useState<string | null>(readStoredToken)
+  const [user, setUser] = useState<AdminUser | null>(null)
+  const [initializing, setInitializing] = useState(() => Boolean(readStoredToken()))
+  const [error, setError] = useState<string | null>(null)
+
+  const logout = useCallback(() => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.removeItem('admin_token')
+    }
+    delete apiClient.defaults.headers.common.Authorization
+    setToken(null)
+    setUser(null)
+  }, [])
+
+  const clearError = useCallback(() => setError(null), [])
+
+  const login = useCallback(
+    async (email: string, password: string) => {
+      clearError()
+      const formData = new URLSearchParams()
+      formData.set('username', email.trim())
+      formData.set('password', password)
+      try {
+        const { data } = await apiClient.post('/auth/login', formData, {
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+        })
+        if (typeof window !== 'undefined') {
+          window.localStorage.setItem('admin_token', data.access_token)
+        }
+        apiClient.defaults.headers.common.Authorization = `Bearer ${data.access_token}`
+        setToken(data.access_token)
+        setUser(data.user)
+      } catch (loginError) {
+        if (axios.isAxiosError(loginError)) {
+          if (loginError.response?.status === 400) {
+            setError('Неверный email или пароль. Проверьте данные и попробуйте снова.')
+          } else {
+            setError('Не удалось выполнить вход. Попробуйте ещё раз позже.')
+          }
+        } else {
+          setError('Произошла непредвиденная ошибка. Повторите попытку позже.')
+        }
+        throw loginError
+      }
+    },
+    [clearError]
+  )
+
+  useEffect(() => {
+    let isMounted = true
+    const verify = async () => {
+      if (!token) {
+        if (isMounted) {
+          setInitializing(false)
+        }
+        return
+      }
+      if (isMounted) {
+        setInitializing(true)
+      }
+      apiClient.defaults.headers.common.Authorization = `Bearer ${token}`
+      try {
+        const { data } = await apiClient.get<AdminUser>('/auth/me')
+        if (isMounted) {
+          setUser(data)
+        }
+      } catch (verifyError) {
+        if (isMounted) {
+          setError('Сессия истекла. Пожалуйста, войдите снова.')
+          logout()
+        }
+      } finally {
+        if (isMounted) {
+          setInitializing(false)
+        }
+      }
+    }
+
+    verify()
+
+    return () => {
+      isMounted = false
+    }
+  }, [token, logout])
+
+  useEffect(() => {
+    const interceptor = apiClient.interceptors.response.use(
+      (response) => response,
+      (responseError) => {
+        if (responseError.response?.status === 401) {
+          setError('Сессия истекла. Пожалуйста, войдите снова.')
+          logout()
+        }
+        return Promise.reject(responseError)
+      }
+    )
+
+    return () => {
+      apiClient.interceptors.response.eject(interceptor)
+    }
+  }, [logout])
+
+  const value = useMemo<AuthContextValue>(
+    () => ({ user, token, initializing, error, login, logout, clearError }),
+    [user, token, initializing, error, login, logout, clearError]
+  )
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+}
+
+export const useAuth = () => {
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider')
+  }
+  return context
+}
+

--- a/dancestudio/admin-frontend/src/main.tsx
+++ b/dancestudio/admin-frontend/src/main.tsx
@@ -2,13 +2,16 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import App from './App'
+import { AuthProvider } from './auth/AuthContext'
 
 const queryClient = new QueryClient()
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </QueryClientProvider>
   </React.StrictMode>
 )

--- a/dancestudio/admin-frontend/src/pages/Login.tsx
+++ b/dancestudio/admin-frontend/src/pages/Login.tsx
@@ -1,0 +1,136 @@
+import { useState, type ChangeEvent, type FormEvent } from 'react'
+import {
+  Alert,
+  Avatar,
+  Box,
+  Button,
+  CircularProgress,
+  Container,
+  Paper,
+  TextField,
+  Typography
+} from '@mui/material'
+import { useAuth } from '../auth/AuthContext'
+
+const LoginPage = () => {
+  const { login, error, clearError } = useAuth()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setIsSubmitting(true)
+    try {
+      await login(email, password)
+    } catch (submitError) {
+      // error is handled by the auth context
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleEmailChange = (event: ChangeEvent<HTMLInputElement>) => {
+    if (error) {
+      clearError()
+    }
+    setEmail(event.target.value)
+  }
+
+  const handlePasswordChange = (event: ChangeEvent<HTMLInputElement>) => {
+    if (error) {
+      clearError()
+    }
+    setPassword(event.target.value)
+  }
+
+  return (
+    <Box
+      sx={{
+        minHeight: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'linear-gradient(135deg, #e0f2ff 0%, #f5f7ff 100%)',
+        py: 6,
+        px: 2
+      }}
+    >
+      <Container maxWidth="sm">
+        <Paper
+          elevation={8}
+          sx={{
+            p: { xs: 4, md: 6 },
+            borderRadius: 4,
+            backdropFilter: 'blur(12px)',
+            backgroundColor: 'rgba(255,255,255,0.95)'
+          }}
+        >
+          <Box textAlign="center" mb={3}>
+            <Avatar
+              sx={{
+                bgcolor: 'primary.main',
+                width: 72,
+                height: 72,
+                mx: 'auto',
+                mb: 2,
+                fontSize: 28,
+                fontWeight: 600
+              }}
+            >
+              DS
+            </Avatar>
+            <Typography component="h1" variant="h4" fontWeight={600} gutterBottom>
+              Добро пожаловать
+            </Typography>
+            <Typography variant="body1" color="text.secondary">
+              Войдите в панель управления студии, чтобы продолжить
+            </Typography>
+          </Box>
+
+          <Box component="form" onSubmit={handleSubmit} display="flex" flexDirection="column" gap={2}>
+            {error && <Alert severity="error">{error}</Alert>}
+            <TextField
+              label="Email"
+              type="email"
+              value={email}
+              onChange={handleEmailChange}
+              placeholder="admin@example.com"
+              fullWidth
+              autoComplete="email"
+              required
+            />
+            <TextField
+              label="Пароль"
+              type="password"
+              value={password}
+              onChange={handlePasswordChange}
+              fullWidth
+              autoComplete="current-password"
+              required
+            />
+            <Button
+              type="submit"
+              variant="contained"
+              size="large"
+              disabled={!email || !password || isSubmitting}
+              sx={{
+                mt: 1,
+                py: 1.5,
+                borderRadius: 3,
+                fontSize: 16,
+                fontWeight: 600,
+                textTransform: 'none'
+              }}
+            >
+              {isSubmitting ? <CircularProgress size={26} color="inherit" /> : 'Войти'}
+            </Button>
+          </Box>
+        </Paper>
+      </Container>
+    </Box>
+  )
+}
+
+export default LoginPage
+


### PR DESCRIPTION
## Summary
- create a reusable auth provider that stores the admin token, verifies sessions, and exposes login/logout helpers
- add a modern login page and show it whenever the admin session is missing or expired
- protect the admin UI with the auth guard and add a top-bar logout button

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9e3fadb308329b5618c1d5799a67d