### PR TITLE
Support username-based admin login and seed default admin

### DIFF
--- a/dancestudio/admin-frontend/src/App.tsx
+++ b/dancestudio/admin-frontend/src/App.tsx
@@ -56,7 +56,7 @@ function App() {
                 Dance Studio Admin
               </Typography>
               <Typography variant="body2" sx={{ mr: 3 }}>
-                {user.email}
+                {user.login}
               </Typography>
               <Button
                 color="inherit"

--- a/dancestudio/admin-frontend/src/auth/AuthContext.tsx
+++ b/dancestudio/admin-frontend/src/auth/AuthContext.tsx
@@ -4,7 +4,7 @@ import { apiClient } from '../api/client'
 
 type AdminUser = {
   id: number
-  email: string
+  login: string
   role: string
 }
 
@@ -13,7 +13,7 @@ type AuthContextValue = {
   token: string | null
   initializing: boolean
   error: string | null
-  login: (email: string, password: string) => Promise<void>
+  login: (login: string, password: string) => Promise<void>
   logout: () => void
   clearError: () => void
 }
@@ -41,10 +41,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const clearError = useCallback(() => setError(null), [])
 
   const login = useCallback(
-    async (email: string, password: string) => {
+    async (loginValue: string, password: string) => {
       clearError()
       const formData = new URLSearchParams()
-      formData.set('username', email.trim())
+      formData.set('username', loginValue.trim())
       formData.set('password', password)
       try {
         const { data } = await apiClient.post('/auth/login', formData, {
@@ -59,7 +59,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       } catch (loginError) {
         if (axios.isAxiosError(loginError)) {
           if (loginError.response?.status === 400) {
-            setError('Неверный email или пароль. Проверьте данные и попробуйте снова.')
+            setError('Неверный логин или пароль. Проверьте данные и попробуйте снова.')
           } else {
             setError('Не удалось выполнить вход. Попробуйте ещё раз позже.')
           }

--- a/dancestudio/admin-frontend/src/pages/Login.tsx
+++ b/dancestudio/admin-frontend/src/pages/Login.tsx
@@ -14,7 +14,7 @@ import { useAuth } from '../auth/AuthContext'
 
 const LoginPage = () => {
   const { login, error, clearError } = useAuth()
-  const [email, setEmail] = useState('')
+  const [loginValue, setLoginValue] = useState('')
   const [password, setPassword] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
 
@@ -22,7 +22,7 @@ const LoginPage = () => {
     event.preventDefault()
     setIsSubmitting(true)
     try {
-      await login(email, password)
+      await login(loginValue, password)
     } catch (submitError) {
       // error is handled by the auth context
     } finally {
@@ -30,11 +30,11 @@ const LoginPage = () => {
     }
   }
 
-  const handleEmailChange = (event: ChangeEvent<HTMLInputElement>) => {
+  const handleLoginChange = (event: ChangeEvent<HTMLInputElement>) => {
     if (error) {
       clearError()
     }
-    setEmail(event.target.value)
+    setLoginValue(event.target.value)
   }
 
   const handlePasswordChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -91,13 +91,13 @@ const LoginPage = () => {
           <Box component="form" onSubmit={handleSubmit} display="flex" flexDirection="column" gap={2}>
             {error && <Alert severity="error">{error}</Alert>}
             <TextField
-              label="Email"
-              type="email"
-              value={email}
-              onChange={handleEmailChange}
-              placeholder="admin@example.com"
+              label="Логин"
+              type="text"
+              value={loginValue}
+              onChange={handleLoginChange}
+              placeholder="admin"
               fullWidth
-              autoComplete="email"
+              autoComplete="username"
               required
             />
             <TextField
@@ -113,7 +113,7 @@ const LoginPage = () => {
               type="submit"
               variant="contained"
               size="large"
-              disabled={!email || !password || isSubmitting}
+              disabled={!loginValue || !password || isSubmitting}
               sx={{
                 mt: 1,
                 py: 1.5,

--- a/dancestudio/backend/app/api/routes/auth.py
+++ b/dancestudio/backend/app/api/routes/auth.py
@@ -24,7 +24,7 @@ def login(
     form_data: OAuth2PasswordRequestForm = Depends(),
     db: Session = Depends(get_db),
 ):
-    admin = db.query(models.AdminUser).filter_by(email=form_data.username).first()
+    admin = db.query(models.AdminUser).filter_by(login=form_data.username).first()
     if not admin or not security.verify_password(form_data.password, admin.password_hash):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid credentials")
     settings = get_settings()
@@ -32,10 +32,10 @@ def login(
     token = security.create_access_token({"sub": str(admin.id), "role": admin.role}, expire)
     admin.last_login_at = datetime.utcnow()
     db.commit()
-    return TokenResponse(access_token=token, user={"id": admin.id, "email": admin.email, "role": admin.role})
+    return TokenResponse(access_token=token, user={"id": admin.id, "login": admin.login, "role": admin.role})
 
 
 @router.get("/me")
 def me(current=Depends(deps.get_current_admin)):
     admin = current
-    return {"id": admin.id, "email": admin.email, "role": admin.role}
+    return {"id": admin.id, "login": admin.login, "role": admin.role}

--- a/dancestudio/backend/app/api/routes/bookings.py
+++ b/dancestudio/backend/app/api/routes/bookings.py
@@ -53,7 +53,7 @@ def cancel_booking(
     if not booking:
         raise HTTPException(status_code=404, detail="Booking not found")
     try:
-        return booking_service.cancel_booking(db, booking, actor=admin.email)
+        return booking_service.cancel_booking(db, booking, actor=admin.login)
     except booking_service.BookingError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)

--- a/dancestudio/backend/app/config.py
+++ b/dancestudio/backend/app/config.py
@@ -28,6 +28,9 @@ class Settings(BaseModel):
     payment_api_key: str = Field(default="", alias="PAYMENT_API_KEY")
     payment_api_secret: str = Field(default="", alias="PAYMENT_API_SECRET")
 
+    default_admin_login: str = Field(default="admin", alias="DEFAULT_ADMIN_LOGIN")
+    default_admin_password: str = Field(default="admin123", alias="DEFAULT_ADMIN_PASSWORD")
+
     google_sheets_enabled: bool = Field(default=False, alias="GOOGLE_SHEETS_ENABLED")
     google_service_account_json_path: str = Field(
         default="", alias="GOOGLE_SERVICE_ACCOUNT_JSON_PATH"

--- a/dancestudio/backend/app/core/auth.py
+++ b/dancestudio/backend/app/core/auth.py
@@ -3,8 +3,8 @@ from ..db import models
 from . import security
 
 
-def authenticate_admin(db: Session, email: str, password: str) -> models.AdminUser | None:
-    admin = db.query(models.AdminUser).filter_by(email=email).first()
+def authenticate_admin(db: Session, login: str, password: str) -> models.AdminUser | None:
+    admin = db.query(models.AdminUser).filter_by(login=login).first()
     if not admin:
         return None
     if not security.verify_password(password, admin.password_hash):

--- a/dancestudio/backend/app/db/migrations/versions/0002_admin_login.py
+++ b/dancestudio/backend/app/db/migrations/versions/0002_admin_login.py
@@ -1,0 +1,41 @@
+"""add login field to admin users
+
+Revision ID: 0002_admin_login
+Revises: 0001_initial
+Create Date: 2024-05-11 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "0002_admin_login"
+down_revision = "0001_initial"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("admin_users") as batch_op:
+        batch_op.add_column(sa.Column("login", sa.String(length=255), nullable=True))
+
+    op.execute("UPDATE admin_users SET login = email")
+
+    with op.batch_alter_table("admin_users") as batch_op:
+        batch_op.alter_column("login", nullable=False)
+        batch_op.create_unique_constraint("uq_admin_users_login", ["login"])
+        batch_op.drop_column("email")
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("admin_users") as batch_op:
+        batch_op.add_column(sa.Column("email", sa.String(length=255), nullable=True))
+
+    op.execute("UPDATE admin_users SET email = login")
+
+    with op.batch_alter_table("admin_users") as batch_op:
+        batch_op.alter_column("email", nullable=False)
+        batch_op.create_unique_constraint("admin_users_email_key", ["email"])
+        batch_op.drop_constraint("uq_admin_users_login", type_="unique")
+        batch_op.drop_column("login")

--- a/dancestudio/backend/app/db/models/admin_user.py
+++ b/dancestudio/backend/app/db/models/admin_user.py
@@ -15,7 +15,7 @@ class AdminUser(Base):
     __tablename__ = "admin_users"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    email: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
+    login: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
     password_hash: Mapped[str] = mapped_column(String(255), nullable=False)
     role: Mapped[AdminRole] = mapped_column(Enum(AdminRole), default=AdminRole.viewer)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())

--- a/dancestudio/backend/app/main.py
+++ b/dancestudio/backend/app/main.py
@@ -1,7 +1,9 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from .api.routes import auth, directions, slots, products, bookings, payments, users, misc
-from .db.session import Base, engine
+from .db.session import Base, engine, SessionLocal
+from .config import get_settings
+from .services.admin import ensure_admin_exists
 
 
 app = FastAPI(title="DanceStudioBot API", version="1.0.0")
@@ -27,3 +29,6 @@ app.include_router(misc.router, prefix="/api/v1")
 @app.on_event("startup")
 async def startup_event() -> None:
     Base.metadata.create_all(bind=engine)
+    settings = get_settings()
+    with SessionLocal() as session:
+        ensure_admin_exists(session, settings.default_admin_login, settings.default_admin_password)

--- a/dancestudio/backend/app/services/admin.py
+++ b/dancestudio/backend/app/services/admin.py
@@ -1,0 +1,22 @@
+import logging
+from sqlalchemy.orm import Session
+
+from ..core import security
+from ..db import models
+
+logger = logging.getLogger(__name__)
+
+
+def ensure_admin_exists(session: Session, login: str, password: str) -> None:
+    existing = session.query(models.AdminUser).filter_by(login=login).first()
+    if existing:
+        logger.info("Admin user '%s' already exists", login)
+        return
+    admin = models.AdminUser(
+        login=login,
+        password_hash=security.get_password_hash(password),
+        role=models.AdminRole.admin,
+    )
+    session.add(admin)
+    session.commit()
+    logger.info("Created default admin user '%s'", login)

--- a/dancestudio/backend/app/services/seed.py
+++ b/dancestudio/backend/app/services/seed.py
@@ -2,17 +2,13 @@ from datetime import datetime, timedelta
 from sqlalchemy.orm import Session
 from ..db.session import SessionLocal
 from ..db import models
-from ..core import security
+from ..config import get_settings
+from .admin import ensure_admin_exists
 
 
 def seed(session: Session) -> None:
-    if session.query(models.AdminUser).count() == 0:
-        admin = models.AdminUser(
-            email="admin@example.com",
-            password_hash=security.get_password_hash("admin123"),
-            role=models.AdminRole.admin,
-        )
-        session.add(admin)
+    settings = get_settings()
+    ensure_admin_exists(session, settings.default_admin_login, settings.default_admin_password)
     if session.query(models.Direction).count() == 0:
         direction = models.Direction(name="Hip-Hop", description="Энергичные занятия")
         session.add(direction)

--- a/dancestudio/backend/tests/test_api_bookings.py
+++ b/dancestudio/backend/tests/test_api_bookings.py
@@ -42,7 +42,7 @@ def api_client():
             db.close()
 
     def override_get_current_admin():
-        return models.AdminUser(id=1, email="admin@example.com", role="admin")
+        return models.AdminUser(id=1, login="admin", role="admin")
 
     routes_pkg_name = "app.api.routes"
     routes_path = Path(__file__).resolve().parents[1] / "app/api/routes"


### PR DESCRIPTION
## Summary
- allow admin authentication to use a generic login field instead of requiring an email
- load default admin credentials from environment variables and create the user automatically on startup
- update the admin frontend to accept the new login workflow and adjust displayed account info
- add an Alembic migration to replace the email column with the new login column

## Testing
- `poetry run pytest` *(fails: existing booking-related tests raise `InvalidRequestError` about nested transactions)*

------
https://chatgpt.com/codex/tasks/task_e_68d9e68aa5788329847145027b9c10f3