### PR TITLE
Normalize product type aliases

### DIFF
--- a/dancestudio/backend/tests/test_product_schemas.py
+++ b/dancestudio/backend/tests/test_product_schemas.py
@@ -1,0 +1,17 @@
+import pytest
+from pydantic import ValidationError
+
+from app.db.models.product import ProductType
+from app.db.schemas.product import ProductCreate
+
+
+def test_product_create_accepts_abon_alias() -> None:
+    product = ProductCreate(type="abon", name="Abon", price=100.0)
+
+    assert product.type is ProductType.subscription
+    assert product.model_dump()["type"] == ProductType.subscription
+
+
+def test_product_create_rejects_unknown_type() -> None:
+    with pytest.raises(ValidationError):
+        ProductCreate(type="unknown", name="Test", price=10.0)


### PR DESCRIPTION
## Summary
- normalize incoming product type values so aliases such as `abon` map onto the expected enum values
- tighten product schema typing to reuse the shared enum definition and prevent unexpected values
- add unit coverage to assert alias handling and validation failures

## Testing
- `poetry run pytest` *(fails: existing tests unrelated to this change raise `InvalidRequestError` because a transaction is already begun on the Session)*

------
https://chatgpt.com/codex/tasks/task_e_68d9ed3e55e08329bada1caedbf58943