### PR TITLE
Add stubbed payment flow and admin payments view

### DIFF
--- a/dancestudio/admin-frontend/src/App.tsx
+++ b/dancestudio/admin-frontend/src/App.tsx
@@ -17,6 +17,7 @@ import DashboardPage from './pages/Dashboard'
 import DirectionsPage from './pages/Directions'
 import SchedulePage from './pages/Schedule'
 import ProductsPage from './pages/Products'
+import PaymentsPage from './pages/Payments'
 import BookingsPage from './pages/Bookings'
 import UsersPage from './pages/Users'
 import SettingsPage from './pages/Settings'
@@ -30,6 +31,7 @@ const tabs = [
   { label: 'Направления', component: <DirectionsPage /> },
   { label: 'Расписание', component: <SchedulePage /> },
   { label: 'Продукты', component: <ProductsPage /> },
+  { label: 'Платежи', component: <PaymentsPage /> },
   { label: 'Бронирования', component: <BookingsPage /> },
   { label: 'Пользователи', component: <UsersPage /> },
   { label: 'Настройки', component: <SettingsPage /> }

--- a/dancestudio/admin-frontend/src/pages/Payments.tsx
+++ b/dancestudio/admin-frontend/src/pages/Payments.tsx
@@ -1,0 +1,69 @@
+import { useQuery } from '@tanstack/react-query'
+import { apiClient } from '../api/client'
+import { Alert, CircularProgress, Box } from '@mui/material'
+import { DataGrid, GridColDef } from '@mui/x-data-grid'
+import dayjs from 'dayjs'
+
+interface Payment {
+  id: number
+  status: string
+  amount: number
+  currency: string
+  purpose: string
+  user_id: number
+  product_id: number | null
+  class_slot_id: number | null
+  created_at: string
+}
+
+const columns: GridColDef<Payment>[] = [
+  { field: 'id', headerName: 'ID', width: 80 },
+  {
+    field: 'created_at',
+    headerName: 'Создано',
+    flex: 1,
+    valueFormatter: (params) => dayjs(params.value as string).format('DD.MM.YYYY HH:mm')
+  },
+  {
+    field: 'amount',
+    headerName: 'Сумма',
+    width: 120,
+    valueFormatter: (params) => `${params.value} ${(params.row.currency as string) ?? '₽'}`
+  },
+  { field: 'currency', headerName: 'Валюта', width: 100 },
+  { field: 'status', headerName: 'Статус', width: 140 },
+  { field: 'purpose', headerName: 'Назначение', width: 160 },
+  { field: 'user_id', headerName: 'Пользователь', width: 140 },
+  { field: 'product_id', headerName: 'Продукт', width: 120 },
+  { field: 'class_slot_id', headerName: 'Слот', width: 120 }
+]
+
+const PaymentsPage = () => {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['payments'],
+    queryFn: async () => {
+      const response = await apiClient.get<Payment[]>('/payments')
+      return response.data
+    }
+  })
+
+  if (isLoading) {
+    return (
+      <Box display="flex" justifyContent="center" mt={4}>
+        <CircularProgress />
+      </Box>
+    )
+  }
+
+  if (error) {
+    return <Alert severity="error">Не удалось загрузить платежи</Alert>
+  }
+
+  return (
+    <Box height={400}>
+      <DataGrid rows={data ?? []} columns={columns} disableRowSelectionOnClick />
+    </Box>
+  )
+}
+
+export default PaymentsPage

--- a/dancestudio/backend/app/config.py
+++ b/dancestudio/backend/app/config.py
@@ -1,6 +1,6 @@
 from functools import lru_cache
-from pydantic import BaseModel, Field
 import os
+from pydantic import BaseModel, Field
 
 
 class Settings(BaseModel):
@@ -22,7 +22,7 @@ class Settings(BaseModel):
     telegram_bot_token: str = Field(default="", alias="TELEGRAM_BOT_TOKEN")
     telegram_admin_ids: str = Field(default="", alias="TELEGRAM_ADMIN_IDS")
 
-    payment_provider: str = Field(default="yookassa", alias="PAYMENT_PROVIDER")
+    payment_provider: str = Field(default="stub", alias="PAYMENT_PROVIDER")
     payment_return_url: str = Field(default="http://localhost", alias="PAYMENT_RETURN_URL")
     payment_webhook_secret: str = Field(default="", alias="PAYMENT_WEBHOOK_SECRET")
     payment_api_key: str = Field(default="", alias="PAYMENT_API_KEY")

--- a/dancestudio/backend/app/db/models/payment.py
+++ b/dancestudio/backend/app/db/models/payment.py
@@ -29,6 +29,7 @@ class PaymentPurpose(str, PyEnum):
 
 
 class PaymentProvider(str, PyEnum):
+    stub = "stub"
     yookassa = "yookassa"
     stripe = "stripe"
     tinkoff = "tinkoff"

--- a/dancestudio/backend/app/services/payments/__init__.py
+++ b/dancestudio/backend/app/services/payments/__init__.py
@@ -1,3 +1,5 @@
 from .gateway import BasePaymentGateway, get_gateway
+from .stub import StubGateway
 from .yookassa import YooKassaGateway
-__all__ = ["BasePaymentGateway", "get_gateway", "YooKassaGateway"]
+
+__all__ = ["BasePaymentGateway", "get_gateway", "StubGateway", "YooKassaGateway"]

--- a/dancestudio/backend/app/services/payments/gateway.py
+++ b/dancestudio/backend/app/services/payments/gateway.py
@@ -25,6 +25,10 @@ class BasePaymentGateway(ABC):
 
 
 def get_gateway(settings: Settings) -> BasePaymentGateway:
+    if settings.payment_provider == "stub":
+        from .stub import StubGateway
+
+        return StubGateway(settings)
     if settings.payment_provider == "yookassa":
         from .yookassa import YooKassaGateway
 

--- a/dancestudio/backend/app/services/payments/stub.py
+++ b/dancestudio/backend/app/services/payments/stub.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .gateway import BasePaymentGateway
+
+
+class StubGateway(BasePaymentGateway):
+    """Simple payment gateway stub that pretends every payment succeeds."""
+
+    def create_payment(
+        self,
+        order_id: str,
+        amount: float,
+        currency: str,
+        description: str,
+        return_url: str,
+        metadata: dict[str, Any],
+    ) -> dict[str, Any]:
+        return {
+            "order_id": order_id,
+            "amount": amount,
+            "currency": currency,
+            "status": "succeeded",
+            "return_url": return_url,
+            "description": description,
+            "metadata": metadata,
+        }
+
+    def parse_webhook(self, data: dict[str, Any]) -> dict[str, Any]:
+        # Webhooks are not used for the stub provider, simply echo data back
+        return {
+            "order_id": data.get("order_id"),
+            "status": data.get("status", "succeeded"),
+            "provider_payment_id": data.get("provider_payment_id"),
+        }


### PR DESCRIPTION
## Summary
- add a stub payment gateway that auto-marks payments as paid and issues subscriptions for paid passes
- improve booking transaction handling and default configuration to use the stub provider
- expose payments in the admin UI and cover the stub flow with backend tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da6914bd508329be18c650704497c3