### PR TITLE
Add Telegram bot booking support with backend endpoints

### DIFF
--- a/dancestudio/backend/app/api/deps.py
+++ b/dancestudio/backend/app/api/deps.py
@@ -1,5 +1,8 @@
 from typing import Annotated
-from fastapi import Depends, HTTPException, status
+import secrets
+from typing import Annotated
+
+from fastapi import Depends, Header, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
 from jose import jwt, JWTError
 from sqlalchemy.orm import Session
@@ -41,3 +44,12 @@ def require_roles(*roles: str):
         return user
 
     return dependency
+
+
+def verify_bot_token(x_bot_token: str | None = Header(default=None)) -> None:
+    settings = get_settings()
+    expected = settings.bot_api_token
+    if not expected:
+        return
+    if not x_bot_token or not secrets.compare_digest(x_bot_token, expected):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid bot token")

--- a/dancestudio/backend/app/api/routes/__init__.py
+++ b/dancestudio/backend/app/api/routes/__init__.py
@@ -1,2 +1,13 @@
-from . import auth, directions, slots, products, bookings, payments, users, misc
-__all__ = ["auth", "directions", "slots", "products", "bookings", "payments", "users", "misc"]
+from . import auth, directions, slots, products, bookings, payments, users, misc, bot
+
+__all__ = [
+    "auth",
+    "directions",
+    "slots",
+    "products",
+    "bookings",
+    "payments",
+    "users",
+    "misc",
+    "bot",
+]

--- a/dancestudio/backend/app/api/routes/bot.py
+++ b/dancestudio/backend/app/api/routes/bot.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from ...api import deps
+from ...db import models, schemas
+from ...db.session import get_db
+from ...services import booking_service, payment_service
+
+router = APIRouter(prefix="/bot", tags=["bot"])
+
+
+class SyncUserRequest(BaseModel):
+    tg_id: int
+    full_name: str | None = None
+    phone: str | None = None
+
+
+class BotBookingSlot(BaseModel):
+    id: int
+    direction_id: int
+    direction_name: str
+    starts_at: datetime
+    duration_min: int
+    price_single_visit: float | None
+    allow_subscription: bool
+
+
+class BotBookingResponse(BaseModel):
+    id: int
+    status: str
+    slot: BotBookingSlot
+    needs_payment: bool
+    payment_status: str | None = None
+    payment_url: str | None = None
+
+
+class BotBookingRequest(SyncUserRequest):
+    slot_id: int
+
+
+def _sync_user(db: Session, payload: SyncUserRequest) -> models.User:
+    user = db.query(models.User).filter_by(tg_id=payload.tg_id).first()
+    created = False
+    if not user:
+        user = models.User(tg_id=payload.tg_id)
+        db.add(user)
+        created = True
+    if payload.full_name is not None:
+        user.full_name = payload.full_name
+    if payload.phone is not None:
+        user.phone = payload.phone
+    if created or payload.full_name is not None or payload.phone is not None:
+        db.commit()
+        db.refresh(user)
+    return user
+
+
+def _latest_payment(db: Session, booking: models.Booking) -> models.Payment | None:
+    return (
+        db.query(models.Payment)
+        .filter_by(class_slot_id=booking.class_slot_id, user_id=booking.user_id)
+        .order_by(models.Payment.created_at.desc())
+        .first()
+    )
+
+
+def _serialize_booking(
+    booking: models.Booking,
+    *,
+    payment: models.Payment | None = None,
+    payment_url: str | None = None,
+) -> BotBookingResponse:
+    slot = booking.slot
+    direction = slot.direction
+    status_value = booking.status.value if hasattr(booking.status, "value") else str(booking.status)
+    payment_status = None
+    if payment:
+        payment_status = payment.status.value if hasattr(payment.status, "value") else str(payment.status)
+    price = float(slot.price_single_visit) if slot.price_single_visit is not None else None
+    return BotBookingResponse(
+        id=booking.id,
+        status=status_value,
+        slot=BotBookingSlot(
+            id=slot.id,
+            direction_id=slot.direction_id,
+            direction_name=direction.name if direction else "",
+            starts_at=slot.starts_at,
+            duration_min=slot.duration_min,
+            price_single_visit=price,
+            allow_subscription=slot.allow_subscription,
+        ),
+        needs_payment=status_value == models.BookingStatus.reserved.value,
+        payment_status=payment_status,
+        payment_url=payment_url,
+    )
+
+
+@router.post("/users/sync", response_model=schemas.User)
+def sync_user(
+    payload: SyncUserRequest,
+    db: Annotated[Session, Depends(get_db)],
+    _: Annotated[None, Depends(deps.verify_bot_token)],
+) -> schemas.User:
+    user = _sync_user(db, payload)
+    return schemas.User.model_validate(user)
+
+
+@router.get("/users/{tg_id}/bookings", response_model=list[BotBookingResponse])
+def list_user_bookings(
+    tg_id: int,
+    db: Annotated[Session, Depends(get_db)],
+    _: Annotated[None, Depends(deps.verify_bot_token)],
+) -> list[BotBookingResponse]:
+    user = db.query(models.User).filter_by(tg_id=tg_id).first()
+    if not user:
+        return []
+    upcoming = (
+        db.query(models.Booking)
+        .join(models.ClassSlot)
+        .filter(models.Booking.user_id == user.id)
+        .filter(models.ClassSlot.starts_at >= datetime.utcnow())
+        .filter(models.Booking.status.in_([models.BookingStatus.confirmed, models.BookingStatus.reserved]))
+        .order_by(models.ClassSlot.starts_at)
+        .all()
+    )
+    results: list[BotBookingResponse] = []
+    for booking in upcoming:
+        payment = _latest_payment(db, booking)
+        results.append(_serialize_booking(booking, payment=payment))
+    return results
+
+
+@router.post("/bookings", response_model=BotBookingResponse)
+def create_booking(
+    payload: BotBookingRequest,
+    db: Annotated[Session, Depends(get_db)],
+    _: Annotated[None, Depends(deps.verify_bot_token)],
+) -> BotBookingResponse:
+    user = _sync_user(db, payload)
+    slot = db.get(models.ClassSlot, payload.slot_id)
+    if not slot:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Slot not found")
+    booking = booking_service.book_class(db, user, slot)
+    db.refresh(booking)
+    payment_url: str | None = None
+    payment = _latest_payment(db, booking)
+    if booking.status == models.BookingStatus.reserved:
+        amount = float(slot.price_single_visit or 0)
+        payment, gateway_response = payment_service.create_payment(
+            db,
+            user,
+            amount=amount,
+            purpose=models.PaymentPurpose.single_visit,
+            slot=slot,
+        )
+        payment_url = gateway_response.get("confirmation_url") or gateway_response.get("return_url")
+        db.refresh(booking)
+    return _serialize_booking(booking, payment=payment, payment_url=payment_url)

--- a/dancestudio/backend/app/api/routes/payments.py
+++ b/dancestudio/backend/app/api/routes/payments.py
@@ -29,7 +29,7 @@ def create_payment_endpoint(
         raise HTTPException(status_code=404, detail="User not found")
     product = db.get(models.Product, payload.product_id) if payload.product_id else None
     slot = db.get(models.ClassSlot, payload.class_slot_id) if payload.class_slot_id else None
-    payment = payment_service.create_payment(
+    payment, _ = payment_service.create_payment(
         db,
         user,
         amount=payload.amount,

--- a/dancestudio/backend/app/config.py
+++ b/dancestudio/backend/app/config.py
@@ -21,6 +21,7 @@ class Settings(BaseModel):
 
     telegram_bot_token: str = Field(default="", alias="TELEGRAM_BOT_TOKEN")
     telegram_admin_ids: str = Field(default="", alias="TELEGRAM_ADMIN_IDS")
+    bot_api_token: str = Field(default="", alias="BOT_API_TOKEN")
 
     payment_provider: str = Field(default="stub", alias="PAYMENT_PROVIDER")
     payment_return_url: str = Field(default="http://localhost", alias="PAYMENT_RETURN_URL")

--- a/dancestudio/backend/app/main.py
+++ b/dancestudio/backend/app/main.py
@@ -1,6 +1,16 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from .api.routes import auth, directions, slots, products, bookings, payments, users, misc
+from .api.routes import (
+    auth,
+    directions,
+    slots,
+    products,
+    bookings,
+    payments,
+    users,
+    misc,
+    bot,
+)
 from .db.session import Base, engine, SessionLocal
 from .config import get_settings
 from .services.admin import ensure_admin_exists
@@ -24,6 +34,7 @@ app.include_router(bookings.router, prefix="/api/v1")
 app.include_router(payments.router, prefix="/api/v1")
 app.include_router(users.router, prefix="/api/v1")
 app.include_router(misc.router, prefix="/api/v1")
+app.include_router(bot.router, prefix="/api/v1")
 
 
 @app.on_event("startup")

--- a/dancestudio/backend/tests/test_bot_api.py
+++ b/dancestudio/backend/tests/test_bot_api.py
@@ -1,0 +1,176 @@
+import importlib
+import sys
+import types
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.config import get_settings
+from app.db import models
+from app.db.session import Base, get_db
+
+
+@pytest.fixture()
+def bot_api_client(monkeypatch):
+    monkeypatch.setenv("BOT_API_TOKEN", "bot-secret")
+    get_settings.cache_clear()
+
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        future=True,
+    )
+    TestingSessionLocal = sessionmaker(
+        bind=engine,
+        autoflush=False,
+        autocommit=False,
+        expire_on_commit=False,
+        future=True,
+    )
+    Base.metadata.create_all(bind=engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    routes_pkg_name = "app.api.routes"
+    routes_path = Path(__file__).resolve().parents[1] / "app/api/routes"
+    original_routes_pkg = sys.modules.get(routes_pkg_name)
+    temp_package = types.ModuleType(routes_pkg_name)
+    temp_package.__path__ = [str(routes_path)]
+    sys.modules[routes_pkg_name] = temp_package
+
+    try:
+        bot_module = importlib.import_module("app.api.routes.bot")
+    finally:
+        if original_routes_pkg is None:
+            sys.modules.pop(routes_pkg_name, None)
+        else:
+            sys.modules[routes_pkg_name] = original_routes_pkg
+
+    bot_router = bot_module.router
+
+    test_app = FastAPI()
+    test_app.include_router(bot_router, prefix="/api/v1")
+
+    test_app.dependency_overrides[get_db] = override_get_db
+
+    with TestClient(test_app) as client:
+        yield client, TestingSessionLocal
+
+    test_app.dependency_overrides.clear()
+    get_settings.cache_clear()
+
+
+def test_sync_user_creates_user(bot_api_client):
+    client, SessionLocal = bot_api_client
+    response = client.post(
+        "/api/v1/bot/users/sync",
+        json={"tg_id": 123, "full_name": "Test User"},
+        headers={"X-Bot-Token": "bot-secret"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["tg_id"] == 123
+    assert data["full_name"] == "Test User"
+
+    db = SessionLocal()
+    user = db.query(models.User).filter_by(tg_id=123).one()
+    assert user.full_name == "Test User"
+    db.close()
+
+
+def test_create_booking_creates_payment(bot_api_client):
+    client, SessionLocal = bot_api_client
+    db = SessionLocal()
+    direction = models.Direction(name="Hip-Hop")
+    db.add(direction)
+    db.commit()
+
+    slot = models.ClassSlot(
+        direction_id=direction.id,
+        starts_at=datetime.utcnow() + timedelta(days=2),
+        duration_min=60,
+        capacity=5,
+        price_single_visit=700,
+    )
+    db.add(slot)
+    db.commit()
+    slot_id = slot.id
+    db.close()
+
+    response = client.post(
+        "/api/v1/bot/bookings",
+        json={"tg_id": 456, "slot_id": slot_id},
+        headers={"X-Bot-Token": "bot-secret"},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "confirmed"
+    assert payload["needs_payment"] is False
+    assert payload["slot"]["id"] == slot_id
+    assert payload["payment_status"] == "paid"
+
+    db = SessionLocal()
+    booking = db.query(models.Booking).one()
+    assert booking.status == models.BookingStatus.confirmed
+    payment = db.query(models.Payment).one()
+    assert payment.purpose == models.PaymentPurpose.single_visit
+    assert payment.user_id == booking.user_id
+    db.close()
+
+
+def test_list_bookings_returns_upcoming(bot_api_client):
+    client, SessionLocal = bot_api_client
+    db = SessionLocal()
+    direction = models.Direction(name="Jazz")
+    db.add(direction)
+    db.commit()
+
+    slot = models.ClassSlot(
+        direction_id=direction.id,
+        starts_at=datetime.utcnow() + timedelta(days=1),
+        duration_min=45,
+        capacity=3,
+        price_single_visit=800,
+    )
+    user = models.User(tg_id=999)
+    db.add_all([slot, user])
+    db.commit()
+
+    booking = models.Booking(
+        user_id=user.id,
+        class_slot_id=slot.id,
+        status=models.BookingStatus.confirmed,
+    )
+    db.add(booking)
+    db.commit()
+    db.close()
+
+    response = client.get(
+        "/api/v1/bot/users/999/bookings",
+        headers={"X-Bot-Token": "bot-secret"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["slot"]["direction_name"] == "Jazz"
+
+
+def test_bot_token_required(bot_api_client):
+    client, _ = bot_api_client
+    response = client.post(
+        "/api/v1/bot/users/sync",
+        json={"tg_id": 1},
+    )
+    assert response.status_code == 401

--- a/dancestudio/backend/tests/test_payments.py
+++ b/dancestudio/backend/tests/test_payments.py
@@ -45,7 +45,7 @@ def test_payment_webhook_idempotent(db_session):
     db_session.add_all([slot, user])
     db_session.commit()
     booking = booking_service.book_class(db_session, user, slot)
-    payment = payment_service.create_payment(
+    payment, _ = payment_service.create_payment(
         db_session,
         user,
         amount=500,
@@ -70,7 +70,7 @@ def test_stub_payment_creates_subscription(db_session):
     db_session.add_all([user, product])
     db_session.commit()
 
-    payment = payment_service.create_payment(
+    payment, _ = payment_service.create_payment(
         db_session,
         user,
         amount=float(product.price),

--- a/dancestudio/bot/config.py
+++ b/dancestudio/bot/config.py
@@ -17,6 +17,7 @@ class BotSettings:
     )
     api_base_url: str = _env("API_BASE_URL", "http://backend:8000/api/v1")
     timezone: str = _env("TIMEZONE", "Europe/Moscow")
+    api_token: str = _env("BOT_API_TOKEN", "")
 
 
 def get_settings() -> BotSettings:

--- a/dancestudio/bot/handlers/menu.py
+++ b/dancestudio/bot/handlers/menu.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Mapping
 from zoneinfo import ZoneInfo
 
 from aiogram import F, Router
 from aiogram.filters import CommandStart
-from aiogram.types import CallbackQuery, Message
+from aiogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup, Message
 from httpx import HTTPError
 
 from config import get_settings
@@ -14,9 +15,17 @@ from keyboards import (
     main_menu_keyboard,
     products_keyboard,
     slots_keyboard,
+    slot_actions_keyboard,
 )
-from services import fetch_directions, fetch_products, fetch_slots
-from services.api_client import Direction, Slot
+from services import (
+    fetch_directions,
+    fetch_products,
+    fetch_slots,
+    fetch_bookings,
+    create_booking,
+    sync_user,
+)
+from services.api_client import Direction
 from utils import texts
 
 router = Router()
@@ -24,20 +33,102 @@ _settings = get_settings()
 _timezone = ZoneInfo(_settings.timezone)
 
 
+async def _safe_edit_message(
+    message: Message, text: str, reply_markup: InlineKeyboardMarkup | None = None
+) -> None:
+    current_text = message.html_text or message.text or ""
+    new_markup_dump = reply_markup.model_dump() if reply_markup else None
+    existing_markup_dump = (
+        message.reply_markup.model_dump() if message.reply_markup else None
+    )
+    if current_text == text and existing_markup_dump == new_markup_dump:
+        return
+    await message.edit_text(text, reply_markup=reply_markup)
+
+
+def _format_price(value: object) -> str:
+    try:
+        number = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return ""
+    text = f"{number:.2f}".rstrip("0").rstrip(".")
+    return f"{text} ₽"
+
+
+def _format_slot_time(slot: Mapping[str, object]) -> tuple[str, str]:
+    raw_starts_at = slot.get("starts_at", "")
+    if isinstance(raw_starts_at, str) and raw_starts_at.endswith("Z"):
+        raw_starts_at = raw_starts_at.replace("Z", "+00:00")
+    if not isinstance(raw_starts_at, str):
+        return "", ""
+    try:
+        dt = datetime.fromisoformat(raw_starts_at)
+    except ValueError:
+        return "", ""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=ZoneInfo("UTC"))
+    dt_local = dt.astimezone(_timezone)
+    short_label = dt_local.strftime("%d.%m %H:%M")
+    long_label = dt_local.strftime("%d.%m.%Y %H:%M")
+    return short_label, long_label
+
+
+def _direction_title(direction: Direction) -> str:
+    name = direction.get("name", "Направление")
+    return texts.direction_schedule_title(name)
+
+
 @router.message(CommandStart())
 async def cmd_start(message: Message) -> None:
+    if message.from_user:
+        try:
+            await sync_user(
+                tg_id=message.from_user.id,
+                full_name=message.from_user.full_name,
+            )
+        except HTTPError:
+            pass
     await message.answer(texts.MAIN_MENU, reply_markup=main_menu_keyboard())
 
 
 @router.callback_query(F.data == "rules")
 async def show_rules(callback: CallbackQuery) -> None:
-    await callback.message.edit_text(texts.CANCEL_RULES, reply_markup=main_menu_keyboard())
+    await _safe_edit_message(
+        callback.message,
+        texts.CANCEL_RULES,
+        reply_markup=main_menu_keyboard(),
+    )
     await callback.answer()
 
 
 @router.callback_query(F.data == "my_bookings")
 async def my_bookings(callback: CallbackQuery) -> None:
-    await callback.answer("Функция в разработке", show_alert=True)
+    user = callback.from_user
+    if not user:
+        await callback.answer(texts.API_ERROR, show_alert=True)
+        return
+    try:
+        await sync_user(tg_id=user.id, full_name=user.full_name)
+    except HTTPError:
+        pass
+    try:
+        bookings = await fetch_bookings(tg_id=user.id)
+    except HTTPError:
+        await callback.answer(texts.API_ERROR, show_alert=True)
+        return
+
+    items: list[tuple[str, str]] = []
+    for booking in bookings:
+        slot = booking.get("slot", {})
+        short_label, _ = _format_slot_time(slot)
+        direction_name = slot.get("direction_name", "") or "Занятие"
+        title = f"{short_label} · {direction_name}" if short_label else direction_name
+        status = str(booking.get("status", ""))
+        items.append((title, status))
+
+    text = texts.bookings_list(items)
+    await _safe_edit_message(callback.message, text, reply_markup=main_menu_keyboard())
+    await callback.answer()
 
 
 @router.callback_query(F.data == "buy_subscription")
@@ -52,7 +143,11 @@ async def show_products(callback: CallbackQuery) -> None:
         await callback.answer(texts.NO_PRODUCTS, show_alert=True)
         return
 
-    await callback.message.edit_text(texts.PRODUCTS_PROMPT, reply_markup=products_keyboard(products))
+    await _safe_edit_message(
+        callback.message,
+        texts.PRODUCTS_PROMPT,
+        reply_markup=products_keyboard(products),
+    )
     await callback.answer()
 
 
@@ -74,7 +169,11 @@ async def product_details(callback: CallbackQuery) -> None:
         await callback.answer(texts.ITEM_NOT_FOUND, show_alert=True)
         return
 
-    await callback.message.edit_text(texts.product_details(product), reply_markup=products_keyboard(products))
+    await _safe_edit_message(
+        callback.message,
+        texts.product_details(product),
+        reply_markup=products_keyboard(products),
+    )
     await callback.answer()
 
 
@@ -90,38 +189,15 @@ async def choose_direction(callback: CallbackQuery) -> None:
         await callback.answer(texts.NO_DIRECTIONS, show_alert=True)
         return
 
-    await callback.message.edit_text(texts.DIRECTIONS_PROMPT, reply_markup=directions_keyboard(directions))
+    await _safe_edit_message(
+        callback.message,
+        texts.DIRECTIONS_PROMPT,
+        reply_markup=directions_keyboard(directions),
+    )
     await callback.answer()
 
 
-def _format_slot_time(slot: Slot) -> tuple[str, str]:
-    starts_at = slot.get("starts_at", "")
-    if starts_at.endswith("Z"):
-        starts_at = starts_at.replace("Z", "+00:00")
-    try:
-        dt = datetime.fromisoformat(starts_at)
-    except ValueError:
-        return "", ""
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=ZoneInfo("UTC"))
-    dt_local = dt.astimezone(_timezone)
-    short_label = dt_local.strftime("%d.%m %H:%M")
-    long_label = dt_local.strftime("%d.%m.%Y %H:%M")
-    return short_label, long_label
-
-
-def _direction_title(direction: Direction) -> str:
-    name = direction.get("name", "Направление")
-    return texts.direction_schedule_title(name)
-
-
-@router.callback_query(F.data.startswith("direction:"))
-async def show_direction_schedule(callback: CallbackQuery) -> None:
-    try:
-        direction_id = int(callback.data.split(":", 1)[1])
-    except (IndexError, ValueError):
-        await callback.answer(texts.ITEM_NOT_FOUND, show_alert=True)
-        return
+async def _show_direction(callback: CallbackQuery, direction_id: int) -> None:
     try:
         directions = await fetch_directions()
         slots = await fetch_slots(direction_id=direction_id)
@@ -135,11 +211,15 @@ async def show_direction_schedule(callback: CallbackQuery) -> None:
         return
 
     if not slots:
-        await callback.message.edit_text(texts.no_slots(direction.get("name", "")), reply_markup=directions_keyboard(directions))
+        await _safe_edit_message(
+            callback.message,
+            texts.no_slots(direction.get("name", "")),
+            reply_markup=directions_keyboard(directions),
+        )
         await callback.answer()
         return
 
-    slot_buttons = []
+    slot_buttons: list[tuple[int, str]] = []
     for slot in slots:
         short_label, _ = _format_slot_time(slot)
         slot_id = slot.get("id")
@@ -152,18 +232,30 @@ async def show_direction_schedule(callback: CallbackQuery) -> None:
         slot_buttons.append((slot_id, text))
 
     if not slot_buttons:
-        await callback.message.edit_text(
+        await _safe_edit_message(
+            callback.message,
             texts.no_slots(direction.get("name", "")),
             reply_markup=directions_keyboard(directions),
         )
         await callback.answer()
         return
 
-    await callback.message.edit_text(
+    await _safe_edit_message(
+        callback.message,
         _direction_title(direction),
         reply_markup=slots_keyboard(direction_id, slot_buttons),
     )
     await callback.answer()
+
+
+@router.callback_query(F.data.startswith("direction:"))
+async def show_direction_schedule(callback: CallbackQuery) -> None:
+    try:
+        direction_id = int(callback.data.split(":", 1)[1])
+    except (IndexError, ValueError):
+        await callback.answer(texts.ITEM_NOT_FOUND, show_alert=True)
+        return
+    await _show_direction(callback, direction_id)
 
 
 @router.callback_query(F.data.startswith("slot:"))
@@ -191,10 +283,86 @@ async def show_slot_details(callback: CallbackQuery) -> None:
         return
 
     _, long_label = _format_slot_time(slot)
-    await callback.answer(
-        texts.slot_details(direction.get("name", ""), slot, long_label),
-        show_alert=True,
+    slot_text = texts.slot_details(direction.get("name", ""), slot, long_label)
+    await _safe_edit_message(
+        callback.message,
+        slot_text,
+        reply_markup=slot_actions_keyboard(direction_id, slot_id),
     )
+    await callback.answer()
+
+
+@router.callback_query(F.data.startswith("back_to_schedule:"))
+async def back_to_schedule(callback: CallbackQuery) -> None:
+    try:
+        direction_id = int(callback.data.split(":", 1)[1])
+    except (IndexError, ValueError):
+        await callback.answer(texts.ITEM_NOT_FOUND, show_alert=True)
+        return
+    await _show_direction(callback, direction_id)
+
+
+@router.callback_query(F.data.startswith("book_slot:"))
+async def book_slot(callback: CallbackQuery) -> None:
+    try:
+        _, direction_id_str, slot_id_str = callback.data.split(":", 2)
+        direction_id = int(direction_id_str)
+        slot_id = int(slot_id_str)
+    except (ValueError, IndexError):
+        await callback.answer(texts.ITEM_NOT_FOUND, show_alert=True)
+        return
+
+    user = callback.from_user
+    if not user:
+        await callback.answer(texts.API_ERROR, show_alert=True)
+        return
+
+    try:
+        result = await create_booking(
+            tg_id=user.id,
+            slot_id=slot_id,
+            full_name=user.full_name,
+        )
+    except HTTPError as exc:
+        if exc.response is not None and exc.response.status_code == 404:
+            await callback.answer(texts.ITEM_NOT_FOUND, show_alert=True)
+        else:
+            await callback.answer(texts.API_ERROR, show_alert=True)
+        return
+
+    slot = result.get("slot", {})
+    _, long_label = _format_slot_time(slot)
+    direction_name = slot.get("direction_name", "")
+    price_text = _format_price(slot.get("price_single_visit"))
+    payment_url = result.get("payment_url")
+    needs_payment = bool(result.get("needs_payment")) and isinstance(payment_url, str)
+
+    await _safe_edit_message(
+        callback.message,
+        texts.MAIN_MENU,
+        reply_markup=main_menu_keyboard(),
+    )
+
+    if needs_payment and isinstance(payment_url, str):
+        text = texts.booking_payment_required(direction_name, long_label, price_text)
+        markup = InlineKeyboardMarkup(
+            inline_keyboard=[
+                [InlineKeyboardButton(text="Оплатить занятие", url=payment_url)],
+                [InlineKeyboardButton(text="Мои записи", callback_data="my_bookings")],
+                [InlineKeyboardButton(text="Главное меню", callback_data="back_main")],
+            ]
+        )
+    else:
+        text = texts.booking_confirmed(direction_name, long_label)
+        markup = InlineKeyboardMarkup(
+            inline_keyboard=[
+                [InlineKeyboardButton(text="Мои записи", callback_data="my_bookings")],
+                [InlineKeyboardButton(text="Главное меню", callback_data="back_main")],
+            ]
+        )
+
+    await callback.message.answer(text, reply_markup=markup)
+    await callback.answer()
 
 
 @router.callback_query(F.data == "back_to_directions")
@@ -209,11 +377,19 @@ async def back_to_directions(callback: CallbackQuery) -> None:
         await callback.answer(texts.NO_DIRECTIONS, show_alert=True)
         return
 
-    await callback.message.edit_text(texts.DIRECTIONS_PROMPT, reply_markup=directions_keyboard(directions))
+    await _safe_edit_message(
+        callback.message,
+        texts.DIRECTIONS_PROMPT,
+        reply_markup=directions_keyboard(directions),
+    )
     await callback.answer()
 
 
 @router.callback_query(F.data == "back_main")
 async def back_to_main(callback: CallbackQuery) -> None:
-    await callback.message.edit_text(texts.MAIN_MENU, reply_markup=main_menu_keyboard())
+    await _safe_edit_message(
+        callback.message,
+        texts.MAIN_MENU,
+        reply_markup=main_menu_keyboard(),
+    )
     await callback.answer()

--- a/dancestudio/bot/keyboards/__init__.py
+++ b/dancestudio/bot/keyboards/__init__.py
@@ -1,11 +1,12 @@
 from .main import main_menu_keyboard
 from .products import products_keyboard
 from .directions import directions_keyboard
-from .slots import slots_keyboard
+from .slots import slots_keyboard, slot_actions_keyboard
 
 __all__ = [
     "main_menu_keyboard",
     "products_keyboard",
     "directions_keyboard",
     "slots_keyboard",
+    "slot_actions_keyboard",
 ]

--- a/dancestudio/bot/keyboards/slots.py
+++ b/dancestudio/bot/keyboards/slots.py
@@ -23,4 +23,24 @@ def slots_keyboard(direction_id: int, slots: Iterable[SlotButton]) -> InlineKeyb
     return InlineKeyboardMarkup(inline_keyboard=keyboard)
 
 
-__all__ = ["slots_keyboard", "SlotButton"]
+def slot_actions_keyboard(direction_id: int, slot_id: int) -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(
+                    text="Записаться",
+                    callback_data=f"book_slot:{direction_id}:{slot_id}",
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text="Назад",
+                    callback_data=f"back_to_schedule:{direction_id}",
+                ),
+                InlineKeyboardButton(text="Главное меню", callback_data="back_main"),
+            ],
+        ]
+    )
+
+
+__all__ = ["slots_keyboard", "slot_actions_keyboard", "SlotButton"]

--- a/dancestudio/bot/services/__init__.py
+++ b/dancestudio/bot/services/__init__.py
@@ -1,7 +1,17 @@
-from .api_client import fetch_products, fetch_directions, fetch_slots
+from .api_client import (
+    fetch_products,
+    fetch_directions,
+    fetch_slots,
+    fetch_bookings,
+    create_booking,
+    sync_user,
+)
 
 __all__ = [
     "fetch_products",
     "fetch_directions",
     "fetch_slots",
+    "fetch_bookings",
+    "create_booking",
+    "sync_user",
 ]

--- a/dancestudio/bot/utils/texts.py
+++ b/dancestudio/bot/utils/texts.py
@@ -10,6 +10,10 @@ NO_DIRECTIONS = "Пока нет активных направлений"
 API_ERROR = "Не удалось получить данные. Попробуйте позже."
 ITEM_NOT_FOUND = "Элемент не найден. Попробуйте обновить список."
 DIRECTIONS_PROMPT = "Выберите направление:"
+NO_BOOKINGS = "У вас пока нет записей."
+BOOKINGS_TITLE = "Ваши записи:"
+BOOKING_CONFIRMED = "Запись подтверждена!"
+BOOKING_PAYMENT_REQUIRED = "Бронь создана, оплатите занятие, чтобы подтвердить запись."
 
 
 def _format_price(value: float | int | None) -> str:
@@ -65,4 +69,45 @@ def slot_details(direction_name: str, slot: Mapping[str, object], starts_at: str
     lines.append("Доступно по абонементу" if allow_subscription else "Без абонемента")
     if isinstance(status, str) and status != "scheduled":
         lines.append(f"Статус: {status}")
+    return "\n".join(lines)
+
+
+def booking_confirmed(direction_name: str, starts_at: str) -> str:
+    clean_direction = direction_name or "Занятие"
+    return (
+        f"{BOOKING_CONFIRMED}\n\n"
+        f"«{clean_direction}»\n{starts_at}\n"
+        "Ждём вас на занятии!"
+    )
+
+
+def booking_payment_required(direction_name: str, starts_at: str, price: str | None) -> str:
+    clean_direction = direction_name or "Занятие"
+    parts = [BOOKING_PAYMENT_REQUIRED, "", f"«{clean_direction}»", starts_at]
+    if price:
+        parts.append(f"Стоимость: {price}")
+    parts.append("Перейдите по ссылке ниже, чтобы оплатить занятие.")
+    return "\n".join(parts)
+
+
+def _status_label(status: str) -> str:
+    mapping = {
+        "confirmed": "подтверждена",
+        "reserved": "ожидает оплаты",
+        "canceled": "отменена",
+        "late_cancel": "поздняя отмена",
+    }
+    return mapping.get(status, status)
+
+
+def bookings_list(items: list[tuple[str, str]]) -> str:
+    if not items:
+        return NO_BOOKINGS
+    lines = [BOOKINGS_TITLE]
+    for title, status in items:
+        status_label = _status_label(status)
+        if status_label:
+            lines.append(f"• {title} ({status_label})")
+        else:
+            lines.append(f"• {title}")
     return "\n".join(lines)


### PR DESCRIPTION
## Summary
- add authenticated bot endpoints for syncing users, listing bookings, and creating paid bookings
- expand the Telegram bot client and handlers to show upcoming bookings and support single-visit payments while preventing redundant message edits
- update payment service return values and cover the new bot API with tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da6d15b11883299655edfd6186432a