### PR TITLE
Add temporary stubs for purchases

### DIFF
--- a/dancestudio/bot/utils/texts.py
+++ b/dancestudio/bot/utils/texts.py
@@ -14,6 +14,14 @@ NO_BOOKINGS = "У вас пока нет записей."
 BOOKINGS_TITLE = "Ваши записи:"
 BOOKING_CONFIRMED = "Запись подтверждена!"
 BOOKING_PAYMENT_REQUIRED = "Бронь создана, оплатите занятие, чтобы подтвердить запись."
+SUBSCRIPTION_PURCHASE_SUCCESS = (
+    "Готово! Абонемент успешно оформлен.\n"
+    "Мы свяжемся с вами для подтверждения деталей."
+)
+CLASS_PURCHASE_SUCCESS = (
+    "Отлично! Занятие успешно оплачено.\n"
+    "Ждём вас на тренировке!"
+)
 
 
 def _format_price(value: float | int | None) -> str:


### PR DESCRIPTION
## Summary
- stub the subscription purchase flow so it immediately reports a successful purchase
- replace the class booking purchase with a success message instead of calling the API
- add reusable success messages for subscription and class purchases

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da76dc23208329a8d0f1687ab80b54