### PR TITLE
Collect full names after payments and show booking details

### DIFF
--- a/dancestudio/admin-frontend/src/pages/Bookings.tsx
+++ b/dancestudio/admin-frontend/src/pages/Bookings.tsx
@@ -10,19 +10,41 @@ interface Booking {
   created_at: string
   user_id: number
   class_slot_id: number
+  user_full_name?: string | null
+  slot_starts_at?: string | null
+  slot_direction_name?: string | null
 }
 
 const columns: GridColDef<Booking>[] = [
   { field: 'id', headerName: 'ID', width: 80 },
   { field: 'status', headerName: 'Статус', width: 120 },
   {
+    field: 'slot_starts_at',
+    headerName: 'Время занятия',
+    flex: 1,
+    valueFormatter: (params) =>
+      params.value ? dayjs(params.value as string).format('DD.MM.YYYY HH:mm') : '—'
+  },
+  {
+    field: 'slot_direction_name',
+    headerName: 'Направление',
+    flex: 1,
+    valueGetter: (params) => params.row.slot_direction_name ?? '—'
+  },
+  {
+    field: 'user_full_name',
+    headerName: 'ФИО',
+    flex: 1,
+    valueGetter: (params) => params.row.user_full_name ?? '—'
+  },
+  {
     field: 'created_at',
     headerName: 'Создано',
-    flex: 1,
+    width: 180,
     valueFormatter: (params) => dayjs(params.value as string).format('DD.MM.YYYY HH:mm')
   },
-  { field: 'user_id', headerName: 'Пользователь', width: 150 },
-  { field: 'class_slot_id', headerName: 'Слот', width: 150 }
+  { field: 'user_id', headerName: 'ID пользователя', width: 140 },
+  { field: 'class_slot_id', headerName: 'ID слота', width: 120 }
 ]
 
 const BookingsPage = () => {

--- a/dancestudio/backend/app/api/routes/bookings.py
+++ b/dancestudio/backend/app/api/routes/bookings.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, selectinload
 from ...api import deps
 from ...db.session import get_db
 from ...db import models, schemas
@@ -15,7 +15,13 @@ def list_bookings(
     db: Session = Depends(get_db),
     _: models.AdminUser = Depends(deps.require_roles("admin", "manager", "viewer")),
 ):
-    query = db.query(models.Booking)
+    query = (
+        db.query(models.Booking)
+        .options(
+            selectinload(models.Booking.user),
+            selectinload(models.Booking.slot).selectinload(models.ClassSlot.direction),
+        )
+    )
     if slot_id:
         query = query.filter(models.Booking.class_slot_id == slot_id)
     if user_id:

--- a/dancestudio/backend/app/db/models/booking.py
+++ b/dancestudio/backend/app/db/models/booking.py
@@ -37,3 +37,19 @@ class Booking(Base):
 
     user = relationship("User")
     slot = relationship("ClassSlot", back_populates="bookings")
+
+    @property
+    def user_full_name(self) -> str | None:
+        return self.user.full_name if self.user else None
+
+    @property
+    def slot_starts_at(self) -> datetime | None:
+        if self.slot:
+            return self.slot.starts_at
+        return None
+
+    @property
+    def slot_direction_name(self) -> str | None:
+        if self.slot and self.slot.direction:
+            return self.slot.direction.name
+        return None

--- a/dancestudio/backend/app/db/schemas/booking.py
+++ b/dancestudio/backend/app/db/schemas/booking.py
@@ -19,6 +19,9 @@ class Booking(BookingBase):
     id: int
     status: str
     created_at: datetime
+    user_full_name: str | None = None
+    slot_starts_at: datetime | None = None
+    slot_direction_name: str | None = None
 
     class Config:
         from_attributes = True

--- a/dancestudio/bot/keyboards/__init__.py
+++ b/dancestudio/bot/keyboards/__init__.py
@@ -1,11 +1,12 @@
 from .main import main_menu_keyboard
-from .products import products_keyboard
+from .products import products_keyboard, product_actions_keyboard
 from .directions import directions_keyboard
 from .slots import slots_keyboard, slot_actions_keyboard
 
 __all__ = [
     "main_menu_keyboard",
     "products_keyboard",
+    "product_actions_keyboard",
     "directions_keyboard",
     "slots_keyboard",
     "slot_actions_keyboard",

--- a/dancestudio/bot/keyboards/products.py
+++ b/dancestudio/bot/keyboards/products.py
@@ -28,8 +28,30 @@ def products_keyboard(products: Sequence[Product]) -> InlineKeyboardMarkup:
         keyboard.append([
             InlineKeyboardButton(text=caption, callback_data=f"product:{product_id}")
         ])
-    keyboard.append([InlineKeyboardButton(text="Назад", callback_data="back_main")])
+    keyboard.append(
+        [
+            InlineKeyboardButton(text="Назад", callback_data="buy_subscription"),
+            InlineKeyboardButton(text="Главное меню", callback_data="back_main"),
+        ]
+    )
     return InlineKeyboardMarkup(inline_keyboard=keyboard)
 
 
-__all__ = ["products_keyboard"]
+def product_actions_keyboard(product_id: int) -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(
+                    text="Купить",
+                    callback_data=f"purchase_product:{product_id}",
+                )
+            ],
+            [
+                InlineKeyboardButton(text="Назад", callback_data="buy_subscription"),
+                InlineKeyboardButton(text="Главное меню", callback_data="back_main"),
+            ],
+        ]
+    )
+
+
+__all__ = ["products_keyboard", "product_actions_keyboard"]

--- a/dancestudio/bot/services/__init__.py
+++ b/dancestudio/bot/services/__init__.py
@@ -4,6 +4,7 @@ from .api_client import (
     fetch_slots,
     fetch_bookings,
     create_booking,
+    create_subscription_payment,
     sync_user,
 )
 
@@ -13,5 +14,6 @@ __all__ = [
     "fetch_slots",
     "fetch_bookings",
     "create_booking",
+    "create_subscription_payment",
     "sync_user",
 ]

--- a/dancestudio/bot/services/api_client.py
+++ b/dancestudio/bot/services/api_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Any, TypedDict
 
 import httpx
@@ -96,9 +97,9 @@ async def fetch_directions(*, active_only: bool = True) -> list[Direction]:
 
 
 async def fetch_slots(*, direction_id: int | None = None) -> list[Slot]:
-    params: dict[str, Any] | None = None
+    params: dict[str, Any] = {"from_dt": datetime.now(timezone.utc).isoformat()}
     if direction_id is not None:
-        params = {"direction_id": direction_id}
+        params["direction_id"] = direction_id
     data = await _get("/slots", params=params)
     return data
 
@@ -127,6 +128,18 @@ async def create_booking(*, tg_id: int, slot_id: int, full_name: str | None = No
     return data
 
 
+async def create_subscription_payment(
+    *, tg_id: int, product_id: int, full_name: str | None = None, phone: str | None = None
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {"tg_id": tg_id, "product_id": product_id}
+    if full_name is not None:
+        payload["full_name"] = full_name
+    if phone is not None:
+        payload["phone"] = phone
+    data = await _post("/bot/payments/subscription", payload)
+    return data
+
+
 __all__ = [
     "Product",
     "Direction",
@@ -138,4 +151,5 @@ __all__ = [
     "fetch_bookings",
     "create_booking",
     "sync_user",
+    "create_subscription_payment",
 ]

--- a/dancestudio/bot/utils/texts.py
+++ b/dancestudio/bot/utils/texts.py
@@ -4,8 +4,8 @@ from typing import Mapping
 
 MAIN_MENU = "Что вы хотите сделать?"
 CANCEL_RULES = "Отмена возможна не позднее чем за 24 часа до занятия."
-PRODUCTS_PROMPT = "Выберите доступный абонемент:"  # noqa: E305
 NO_PRODUCTS = "Пока нет доступных абонементов"
+PRODUCTS_PROMPT = "Выберите абонемент:"
 NO_DIRECTIONS = "Пока нет активных направлений"
 API_ERROR = "Не удалось получить данные. Попробуйте позже."
 ITEM_NOT_FOUND = "Элемент не найден. Попробуйте обновить список."
@@ -14,6 +14,7 @@ NO_BOOKINGS = "У вас пока нет записей."
 BOOKINGS_TITLE = "Ваши записи:"
 BOOKING_CONFIRMED = "Запись подтверждена!"
 BOOKING_PAYMENT_REQUIRED = "Бронь создана, оплатите занятие, чтобы подтвердить запись."
+SUBSCRIPTION_PAYMENT_REQUIRED = "Оплатите абонемент, чтобы завершить оформление."
 SUBSCRIPTION_PURCHASE_SUCCESS = (
     "Готово! Абонемент успешно оформлен.\n"
     "Мы свяжемся с вами для подтверждения деталей."
@@ -22,6 +23,12 @@ CLASS_PURCHASE_SUCCESS = (
     "Отлично! Занятие успешно оплачено.\n"
     "Ждём вас на тренировке!"
 )
+ALREADY_BOOKED = "Вы уже записаны на это занятие."
+ASK_FULL_NAME = "Пожалуйста, напишите ваше полное ФИО."
+FULL_NAME_SAVED = "Спасибо! Мы сохранили ваше ФИО."
+FULL_NAME_INVALID = "Пожалуйста, отправьте ФИО текстом."
+PAST_SLOT_ERROR = "Запись на прошедшее занятие недоступна."
+NO_SEATS_ERROR = "Свободных мест не осталось."
 
 
 def _format_price(value: float | int | None) -> str:
@@ -29,6 +36,10 @@ def _format_price(value: float | int | None) -> str:
         return ""
     text = f"{float(value):.2f}".rstrip("0").rstrip(".")
     return f"{text} ₽"
+
+
+def format_price(value: float | int | None) -> str:
+    return _format_price(value)
 
 
 def product_details(product: Mapping[str, object]) -> str:
@@ -95,6 +106,15 @@ def booking_payment_required(direction_name: str, starts_at: str, price: str | N
     if price:
         parts.append(f"Стоимость: {price}")
     parts.append("Перейдите по ссылке ниже, чтобы оплатить занятие.")
+    return "\n".join(parts)
+
+
+def subscription_payment_details(product_name: str, price: str | None) -> str:
+    clean_name = product_name or "Абонемент"
+    parts = [SUBSCRIPTION_PAYMENT_REQUIRED, "", f"«{clean_name}»"]
+    if price:
+        parts.append(f"Стоимость: {price}")
+    parts.append("Перейдите по ссылке ниже, чтобы оплатить.")
     return "\n".join(parts)
 
 


### PR DESCRIPTION
## Summary
- expose booking slot timing and user full names via the admin API and update the grid columns
- add bot subscription payment API and filter bookings to future slots while preventing duplicate reservations
- teach the bot to list subscriptions, send payment links, and prompt users to provide their full names after booking

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68da78ec7a348329bc02357d14817cd4