### PR TITLE
Add Telegram payments demo bot scaffolding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Telegram bot token
+BOT_TOKEN=123456:ABC...
+
+# Payment provider token from @BotFather (Payments → YooKassa)
+PROVIDER_TOKEN=381764678:TEST:...
+
+# Product details
+ITEM_TITLE=Подписка на месяц
+ITEM_DESCRIPTION=Доступ к премиум-функциям на 30 дней
+
+# Price in minor currency units (kopecks)
+PRICE_RUB_CENTS=19900
+
+# ISO currency code
+CURRENCY=RUB

--- a/README_PAYMENTS.md
+++ b/README_PAYMENTS.md
@@ -1,0 +1,41 @@
+# Telegram Payments Demo (YooKassa)
+
+Этот пример показывает, как подключить оплату через Telegram Bot Payments API с провайдером YooKassa на aiogram v3.
+
+## Требования
+
+- Python 3.11+
+- Установленные зависимости из `requirements.txt`
+
+## Быстрый старт
+
+1. Установите зависимости:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Скопируйте файл окружения и заполните значения:
+   ```bash
+   cp .env.example .env
+   ```
+   Отредактируйте `.env`, указав реальные токены и параметры товара.
+3. В @BotFather включите Payments, выберите провайдера **YooKassa** и получите *Provider Token*. Вставьте его в `.env` (переменная `PROVIDER_TOKEN`).
+4. Запустите демо-бота:
+   ```bash
+   python main_payments_demo.py
+   ```
+
+## Проверка
+
+- `/start` → бот отправляет приветствие и кнопку «Купить».
+- `/buy` → приходит invoice с кнопкой «Оплатить».
+- Проведите тестовую оплату → бот отправит сообщение «Оплата прошла успешно…» с реквизитами платежа.
+
+## Частые ошибки
+
+- `PAYMENT_PROVIDER_INVALID` → проверьте, что используете Provider Token из @BotFather и выбран провайдер YooKassa.
+- Нет `successful_payment` → убедитесь, что обработчик `pre_checkout_query` отвечает `ok=True`.
+- Неверная сумма → укажите цену в копейках (`PRICE_RUB_CENTS`).
+
+## Встраивание в проект
+
+Импортируйте `handlers.payments.router` в свой `Dispatcher` и добавьте обработчики, как показано в `main_payments_demo.py`.

--- a/config.py
+++ b/config.py
@@ -1,0 +1,74 @@
+"""Application configuration loading utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from pathlib import Path
+from typing import Final
+
+from dotenv import load_dotenv
+
+
+ENV_FILE_PATH: Final[Path] = Path(".env")
+
+
+@dataclass(frozen=True, slots=True)
+class Settings:
+    """Dataclass describing configuration values loaded from the environment."""
+
+    bot_token: str
+    provider_token: str
+    item_title: str
+    item_description: str
+    price_cents: int
+    currency: str = "RUB"
+
+
+def get_settings() -> Settings:
+    """Load application settings from ``.env`` file and validate required values.
+
+    Returns:
+        Settings: A populated Settings instance with validated configuration values.
+
+    Raises:
+        RuntimeError: If mandatory environment variables are missing or invalid.
+    """
+
+    load_dotenv(dotenv_path=ENV_FILE_PATH, override=False)
+
+    bot_token = os.getenv("BOT_TOKEN")
+    if not bot_token:
+        raise RuntimeError("Environment variable BOT_TOKEN is required but was not provided.")
+
+    provider_token = os.getenv("PROVIDER_TOKEN")
+    if not provider_token:
+        raise RuntimeError(
+            "Environment variable PROVIDER_TOKEN is required but was not provided."
+        )
+
+    item_title = os.getenv("ITEM_TITLE", "")
+    item_description = os.getenv("ITEM_DESCRIPTION", "")
+
+    price_raw = os.getenv("PRICE_RUB_CENTS")
+    if price_raw is None:
+        raise RuntimeError(
+            "Environment variable PRICE_RUB_CENTS is required but was not provided."
+        )
+    try:
+        price_cents = int(price_raw)
+    except (TypeError, ValueError) as exc:  # pragma: no cover - defensive guard.
+        raise RuntimeError("Environment variable PRICE_RUB_CENTS must be an integer.") from exc
+
+    currency = os.getenv("CURRENCY", "RUB") or "RUB"
+
+    return Settings(
+        bot_token=bot_token,
+        provider_token=provider_token,
+        item_title=item_title,
+        item_description=item_description,
+        price_cents=price_cents,
+        currency=currency,
+    )
+
+
+__all__ = ["Settings", "get_settings"]

--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -1,0 +1,4 @@
+"""Routers for the payments demo bot."""
+from . import common, payments
+
+__all__ = ["common", "payments"]

--- a/handlers/common.py
+++ b/handlers/common.py
@@ -1,0 +1,31 @@
+"""Common UX-related handlers for the demo bot."""
+from __future__ import annotations
+
+from aiogram import F, Router
+from aiogram.filters import CommandStart
+from aiogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup, Message
+
+
+router = Router()
+
+
+@router.message(CommandStart())
+async def handle_start(message: Message) -> None:
+    """Greet the user and show a button to start the purchase flow."""
+
+    keyboard = InlineKeyboardMarkup(
+        inline_keyboard=[[InlineKeyboardButton(text="Купить", callback_data="go_buy")]]
+    )
+    await message.answer(
+        "Привет! Это демо оплаты через Telegram Payments с YooKassa.\n"
+        "Нажмите кнопку ниже, чтобы открыть форму оплаты.",
+        reply_markup=keyboard,
+    )
+
+
+@router.callback_query(F.data == "go_buy")
+async def handle_go_buy(callback: CallbackQuery) -> None:
+    """Prompt the user to use the /buy command when they tap the button."""
+
+    await callback.message.answer("Для оформления заказа отправьте команду /buy")
+    await callback.answer()

--- a/handlers/payments.py
+++ b/handlers/payments.py
@@ -1,0 +1,65 @@
+"""Payment-related Telegram bot handlers using Telegram Bot Payments API."""
+from __future__ import annotations
+
+from aiogram import Router
+from aiogram.filters import Command
+from aiogram.types import LabeledPrice, Message, PreCheckoutQuery
+from aiogram.utils.payload import generate_payload
+from aiogram import F
+
+from config import get_settings
+
+
+router = Router()
+settings = get_settings()
+
+
+@router.message(Command("buy"))
+async def handle_buy_command(message: Message) -> None:
+    """Send an invoice for the premium subscription purchase."""
+
+    payload: str = generate_payload()
+    prices = [LabeledPrice(label=settings.item_title, amount=settings.price_cents)]
+
+    await message.answer_invoice(
+        title=settings.item_title,
+        description=settings.item_description[:255],
+        payload=payload,
+        provider_token=settings.provider_token,
+        currency=settings.currency,
+        prices=prices,
+        need_name=False,
+        need_email=False,
+        need_phone_number=False,
+        need_shipping_address=False,
+    )
+
+
+@router.pre_checkout_query()
+async def handle_pre_checkout_query(pre_checkout_query: PreCheckoutQuery) -> None:
+    """Acknowledge the pre-checkout query to allow the payment to proceed."""
+
+    await pre_checkout_query.answer(ok=True)
+
+
+@router.message(F.successful_payment)
+async def handle_successful_payment(message: Message) -> None:
+    """Respond to the user after a successful payment."""
+
+    successful_payment = message.successful_payment
+    if successful_payment is None:  # Defensive guard for type checkers.
+        return
+
+    order_id = successful_payment.invoice_payload
+
+    text = (
+        "✅ Оплата прошла успешно!\n"
+        f"Заказ: `{order_id}`\n"
+        f"Сумма: {successful_payment.total_amount / 100:.2f} {successful_payment.currency}\n"
+        f"tg_charge_id: `{successful_payment.telegram_payment_charge_id}`\n"
+        f"provider_charge_id: `{successful_payment.provider_payment_charge_id}`"
+    )
+
+    await message.answer(text, parse_mode="Markdown")
+
+    # Здесь можно сохранить платёж и order_id в базу данных проекта.

--- a/main_payments_demo.py
+++ b/main_payments_demo.py
@@ -1,0 +1,32 @@
+"""Entry point for the standalone payments demo bot."""
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from aiogram import Bot, Dispatcher
+
+from config import get_settings
+from handlers import common, payments
+
+
+async def main() -> None:
+    """Configure and launch the Telegram bot via long polling."""
+
+    logging.basicConfig(level=logging.INFO)
+
+    settings = get_settings()
+
+    bot = Bot(token=settings.bot_token, parse_mode="HTML")
+    dp = Dispatcher()
+
+    dp.include_router(common.router)
+    dp.include_router(payments.router)
+
+    logging.info("Bot is running…")
+
+    await dp.start_polling(bot)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+aiogram==3.10.0
+python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- add configuration loader with validation for Telegram payments demo
- implement common UX and payments handlers for aiogram v3
- provide demo entrypoint, environment template, requirements, and README instructions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfd3427e308329a627c472bcc6fee2