### PR TITLE
Cancel unpaid reservations after 20 minutes and surface real stats

### DIFF
--- a/dancestudio/admin-frontend/src/pages/Dashboard.tsx
+++ b/dancestudio/admin-frontend/src/pages/Dashboard.tsx
@@ -1,24 +1,98 @@
-import { Card, CardContent, Grid, Typography } from '@mui/material'
+import { useEffect, useMemo, useState } from 'react'
+import { Alert, Box, Card, CardContent, CircularProgress, Grid, Typography } from '@mui/material'
 
-const stats = [
-  { title: 'Записей сегодня', value: 12 },
-  { title: 'Посещаемость', value: '85%' },
-  { title: 'Выручка (неделя)', value: '120 000 ₽' }
-]
+import { apiClient } from '../api/client'
 
-const DashboardPage = () => (
-  <Grid container spacing={2}>
-    {stats.map((item) => (
-      <Grid item xs={12} md={4} key={item.title}>
-        <Card>
-          <CardContent>
-            <Typography variant="h6">{item.title}</Typography>
-            <Typography variant="h4">{item.value}</Typography>
-          </CardContent>
-        </Card>
-      </Grid>
-    ))}
-  </Grid>
-)
+type DashboardStats = {
+  total: number
+  confirmed: number
+  bookings_today: number
+  attendance_rate: number
+  weekly_revenue: number
+}
+
+const DashboardPage = () => {
+  const [stats, setStats] = useState<DashboardStats | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let isMounted = true
+
+    const fetchStats = async () => {
+      try {
+        const response = await apiClient.get<DashboardStats>('/bookings/stats')
+        if (isMounted) {
+          setStats(response.data)
+        }
+      } catch (err) {
+        if (isMounted) {
+          setError('Не удалось загрузить статистику')
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false)
+        }
+      }
+    }
+
+    void fetchStats()
+
+    return () => {
+      isMounted = false
+    }
+  }, [])
+
+  const statItems = useMemo(() => {
+    if (!stats) {
+      return [
+        { title: 'Записей сегодня', value: '0' },
+        { title: 'Посещаемость', value: '0%' },
+        { title: 'Выручка (неделя)', value: '0 ₽' }
+      ]
+    }
+
+    const attendance = `${Math.round(stats.attendance_rate)}%`
+    const revenueFormatter = new Intl.NumberFormat('ru-RU', {
+      style: 'currency',
+      currency: 'RUB',
+      maximumFractionDigits: 0
+    })
+    const revenue = revenueFormatter.format(stats.weekly_revenue)
+
+    return [
+      { title: 'Записей сегодня', value: stats.bookings_today.toString() },
+      { title: 'Посещаемость', value: attendance },
+      { title: 'Выручка (неделя)', value: revenue }
+    ]
+  }, [stats])
+
+  if (loading) {
+    return (
+      <Box display="flex" justifyContent="center" alignItems="center" minHeight={200}>
+        <CircularProgress />
+      </Box>
+    )
+  }
+
+  if (error) {
+    return <Alert severity="error">{error}</Alert>
+  }
+
+  return (
+    <Grid container spacing={2}>
+      {statItems.map((item) => (
+        <Grid item xs={12} md={4} key={item.title}>
+          <Card>
+            <CardContent>
+              <Typography variant="h6">{item.title}</Typography>
+              <Typography variant="h4">{item.value}</Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+      ))}
+    </Grid>
+  )
+}
 
 export default DashboardPage

--- a/dancestudio/backend/app/core/constants.py
+++ b/dancestudio/backend/app/core/constants.py
@@ -1,0 +1,17 @@
+"""Common application-wide constants."""
+
+from datetime import timedelta
+
+# How long a booking can remain in the ``reserved`` state without payment
+RESERVATION_PAYMENT_TIMEOUT = timedelta(minutes=20)
+
+# Metadata for system-driven booking cancellations
+PAYMENT_TIMEOUT_REASON = "payment_timeout"
+SYSTEM_ACTOR = "system"
+
+
+__all__ = [
+    "RESERVATION_PAYMENT_TIMEOUT",
+    "PAYMENT_TIMEOUT_REASON",
+    "SYSTEM_ACTOR",
+]

--- a/dancestudio/backend/app/db/migrations/versions/0003_add_payment_confirmation_url.py
+++ b/dancestudio/backend/app/db/migrations/versions/0003_add_payment_confirmation_url.py
@@ -1,0 +1,26 @@
+"""Add confirmation_url column to payments
+
+Revision ID: 0003_add_payment_confirmation_url
+Revises: 0002_admin_login
+Create Date: 2024-05-26
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0003_add_payment_confirmation_url"
+down_revision = "0002_admin_login"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "payments",
+        sa.Column("confirmation_url", sa.String(length=512), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("payments", "confirmation_url")

--- a/dancestudio/backend/app/db/models/payment.py
+++ b/dancestudio/backend/app/db/models/payment.py
@@ -49,6 +49,7 @@ class Payment(Base):
     provider: Mapped[PaymentProvider] = mapped_column(Enum(PaymentProvider))
     order_id: Mapped[str] = mapped_column(String(64), unique=True, index=True)
     provider_payment_id: Mapped[str | None] = mapped_column(String(128))
+    confirmation_url: Mapped[str | None] = mapped_column(String(512))
     status: Mapped[PaymentStatus] = mapped_column(Enum(PaymentStatus), default=PaymentStatus.pending)
     purpose: Mapped[PaymentPurpose] = mapped_column(Enum(PaymentPurpose))
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())

--- a/dancestudio/backend/app/workers/scheduler.py
+++ b/dancestudio/backend/app/workers/scheduler.py
@@ -1,8 +1,16 @@
 from datetime import datetime, timedelta
 import logging
+
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
-from ..db.session import SessionLocal
+from sqlalchemy import and_
+
+from ..core.constants import (
+    PAYMENT_TIMEOUT_REASON,
+    RESERVATION_PAYMENT_TIMEOUT,
+    SYSTEM_ACTOR,
+)
 from ..db import models
+from ..db.session import SessionLocal
 
 logger = logging.getLogger(__name__)
 
@@ -20,14 +28,34 @@ def send_reminders() -> None:
 
 def cleanup_reserved() -> None:
     with SessionLocal() as db:
+        now = datetime.utcnow()
+        cutoff = now - RESERVATION_PAYMENT_TIMEOUT
         stale = (
             db.query(models.Booking)
             .filter(models.Booking.status == models.BookingStatus.reserved)
-            .filter(models.Booking.created_at < datetime.utcnow() - timedelta(hours=2))
+            .filter(models.Booking.created_at < cutoff)
             .all()
         )
         for booking in stale:
             booking.status = models.BookingStatus.canceled
+            booking.canceled_at = now
+            booking.canceled_by = SYSTEM_ACTOR
+            booking.cancellation_reason = PAYMENT_TIMEOUT_REASON
+            pending_payments = (
+                db.query(models.Payment)
+                .filter(
+                    and_(
+                        models.Payment.class_slot_id == booking.class_slot_id,
+                        models.Payment.user_id == booking.user_id,
+                        models.Payment.status == models.PaymentStatus.pending,
+                    )
+                )
+                .all()
+            )
+            for payment in pending_payments:
+                payment.status = models.PaymentStatus.canceled
+                payment.updated_at = now
+                payment.confirmation_url = None
         db.commit()
 
 
@@ -47,6 +75,6 @@ def process_waitlist() -> None:
 def get_scheduler() -> AsyncIOScheduler:
     scheduler = AsyncIOScheduler()
     scheduler.add_job(send_reminders, "interval", hours=1)
-    scheduler.add_job(cleanup_reserved, "interval", hours=1)
+    scheduler.add_job(cleanup_reserved, "interval", minutes=1)
     scheduler.add_job(process_waitlist, "interval", minutes=30)
     return scheduler

--- a/dancestudio/bot/services/api_client.py
+++ b/dancestudio/bot/services/api_client.py
@@ -55,6 +55,7 @@ class Booking(TypedDict, total=False):
     needs_payment: bool
     payment_status: str | None
     payment_url: str | None
+    reservation_expires_at: str | None
 
 
 _settings = get_settings()

--- a/dancestudio/bot/utils/texts.py
+++ b/dancestudio/bot/utils/texts.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Mapping
+from typing import Mapping, Sequence
 
 MAIN_MENU = "Что вы хотите сделать?"
 CANCEL_RULES = "Отмена возможна не позднее чем за 24 часа до занятия."
@@ -128,13 +128,34 @@ def _status_label(status: str) -> str:
     return mapping.get(status, status)
 
 
-def bookings_list(items: list[tuple[str, str]]) -> str:
+def bookings_list(items: Sequence[Mapping[str, object]]) -> str:
     if not items:
         return NO_BOOKINGS
     lines = [BOOKINGS_TITLE]
-    for title, status in items:
+    for item in items:
+        title = str(item.get("title", ""))
+        status = str(item.get("status", ""))
+        note_value = item.get("note")
+        note = str(note_value) if isinstance(note_value, str) and note_value else ""
         status_label = _status_label(status)
-        if status_label:
+        if status == "reserved":
+            payment_due_value = item.get("payment_due")
+            payment_due = (
+                str(payment_due_value)
+                if isinstance(payment_due_value, str) and payment_due_value
+                else ""
+            )
+            parts = [title]
+            if payment_due:
+                parts.append(f"бронь до {payment_due}")
+            if note:
+                parts.append(note)
+            else:
+                parts.append("требуется оплата")
+            lines.append("• " + " — ".join(part for part in parts if part))
+        elif note:
+            lines.append(f"• {title} ({note})")
+        elif status_label:
             lines.append(f"• {title} ({status_label})")
         else:
             lines.append(f"• {title}")


### PR DESCRIPTION
## Summary
- cancel unpaid reservations after a 20-minute timeout and cancel stale payments
- persist payment confirmation URLs and expose reservation expiry/payment links to the bot
- load real booking/revenue metrics on the admin dashboard from the backend stats endpoint

## Testing
- pytest tests/test_bot_api.py tests/test_api_bookings.py

------
https://chatgpt.com/codex/tasks/task_e_68e0196f934083299e3a82603561139b