### PR TITLE
Add admin-managed studio addresses

### DIFF
--- a/dancestudio/backend/app/api/routes/__init__.py
+++ b/dancestudio/backend/app/api/routes/__init__.py
@@ -1,4 +1,15 @@
-from . import auth, directions, slots, products, bookings, payments, users, misc, bot
+from . import (
+    auth,
+    directions,
+    slots,
+    products,
+    bookings,
+    payments,
+    users,
+    misc,
+    bot,
+    settings,
+)
 
 __all__ = [
     "auth",
@@ -10,4 +21,5 @@ __all__ = [
     "users",
     "misc",
     "bot",
+    "settings",
 ]

--- a/dancestudio/backend/app/api/routes/bot.py
+++ b/dancestudio/backend/app/api/routes/bot.py
@@ -12,7 +12,7 @@ from ...api import deps
 from ...core.constants import RESERVATION_PAYMENT_TIMEOUT
 from ...db import models, schemas
 from ...db.session import get_db
-from ...services import booking_service, payment_service
+from ...services import booking_service, payment_service, settings_service
 
 router = APIRouter(prefix="/bot", tags=["bot"])
 
@@ -129,6 +129,15 @@ def sync_user(
 ) -> schemas.User:
     user = _sync_user(db, payload)
     return schemas.User.model_validate(user)
+
+
+@router.get("/addresses", response_model=schemas.StudioAddresses)
+def get_addresses(
+    db: Annotated[Session, Depends(get_db)],
+    _: Annotated[None, Depends(deps.verify_bot_token)],
+) -> schemas.StudioAddresses:
+    addresses = settings_service.get_addresses(db)
+    return schemas.StudioAddresses(addresses=addresses)
 
 
 @router.get("/users/{tg_id}/bookings", response_model=list[BotBookingResponse])

--- a/dancestudio/backend/app/api/routes/settings.py
+++ b/dancestudio/backend/app/api/routes/settings.py
@@ -1,0 +1,28 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from ...api import deps
+from ...db import schemas
+from ...db.session import get_db
+from ...services import settings_service
+
+router = APIRouter(prefix="/settings", tags=["settings"])
+
+
+@router.get("/addresses", response_model=schemas.StudioAddresses)
+def get_addresses(
+    db: Session = Depends(get_db),
+    _: None = Depends(deps.require_roles("admin", "manager")),
+) -> schemas.StudioAddresses:
+    addresses = settings_service.get_addresses(db)
+    return schemas.StudioAddresses(addresses=addresses)
+
+
+@router.put("/addresses", response_model=schemas.StudioAddresses)
+def update_addresses(
+    payload: schemas.StudioAddressesUpdate,
+    db: Session = Depends(get_db),
+    _: None = Depends(deps.require_roles("admin", "manager")),
+) -> schemas.StudioAddresses:
+    addresses = settings_service.update_addresses(db, addresses=payload.addresses)
+    return schemas.StudioAddresses(addresses=addresses)

--- a/dancestudio/backend/app/db/migrations/versions/0004_add_settings_table.py
+++ b/dancestudio/backend/app/db/migrations/versions/0004_add_settings_table.py
@@ -1,0 +1,34 @@
+"""Add settings table
+
+Revision ID: 0004_add_settings_table
+Revises: 0003_add_payment_confirmation_url
+Create Date: 2024-06-06
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0004_add_settings_table"
+down_revision = "0003_add_payment_confirmation_url"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "settings",
+        sa.Column("key", sa.String(length=64), nullable=False),
+        sa.Column("value", sa.Text(), nullable=True),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("key"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("settings")

--- a/dancestudio/backend/app/db/models/__init__.py
+++ b/dancestudio/backend/app/db/models/__init__.py
@@ -8,3 +8,4 @@ from .payment import Payment, PaymentStatus, PaymentPurpose, PaymentProvider
 from .waitlist import Waitlist, WaitlistStatus
 from .admin_user import AdminUser, AdminRole
 from .audit_log import AuditLog, ActorType
+from .setting import Setting

--- a/dancestudio/backend/app/db/models/setting.py
+++ b/dancestudio/backend/app/db/models/setting.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ..session import Base
+
+
+class Setting(Base):
+    __tablename__ = "settings"
+
+    key: Mapped[str] = mapped_column(String(64), primary_key=True)
+    value: Mapped[str | None] = mapped_column(Text, nullable=True)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )

--- a/dancestudio/backend/app/db/schemas/__init__.py
+++ b/dancestudio/backend/app/db/schemas/__init__.py
@@ -4,3 +4,4 @@ from .product import Product, ProductCreate, ProductUpdate
 from .booking import Booking, BookingCreate, BookingCancel
 from .payment import Payment, PaymentCreate, PaymentWebhook
 from .user import User, UserUpdate
+from .setting import StudioAddresses, StudioAddressesUpdate

--- a/dancestudio/backend/app/db/schemas/setting.py
+++ b/dancestudio/backend/app/db/schemas/setting.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class StudioAddresses(BaseModel):
+    addresses: str
+
+
+class StudioAddressesUpdate(BaseModel):
+    addresses: str

--- a/dancestudio/backend/app/main.py
+++ b/dancestudio/backend/app/main.py
@@ -10,6 +10,7 @@ from .api.routes import (
     users,
     misc,
     bot,
+    settings,
 )
 from .db.session import Base, engine, SessionLocal
 from .config import get_settings
@@ -35,6 +36,7 @@ app.include_router(payments.router, prefix="/api/v1")
 app.include_router(users.router, prefix="/api/v1")
 app.include_router(misc.router, prefix="/api/v1")
 app.include_router(bot.router, prefix="/api/v1")
+app.include_router(settings.router, prefix="/api/v1")
 
 
 @app.on_event("startup")

--- a/dancestudio/backend/app/services/__init__.py
+++ b/dancestudio/backend/app/services/__init__.py
@@ -1,7 +1,14 @@
-from . import booking_service, payment_service, schedule_service, google_sheets
+from . import (
+    booking_service,
+    payment_service,
+    schedule_service,
+    google_sheets,
+    settings_service,
+)
 __all__ = [
     "booking_service",
     "payment_service",
     "schedule_service",
     "google_sheets",
+    "settings_service",
 ]

--- a/dancestudio/backend/app/services/settings_service.py
+++ b/dancestudio/backend/app/services/settings_service.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from ..db import models
+
+ADDRESSES_KEY = "studio_addresses"
+
+
+def get_addresses(db: Session) -> str:
+    setting = db.get(models.Setting, ADDRESSES_KEY)
+    return setting.value if setting and setting.value is not None else ""
+
+
+def update_addresses(db: Session, *, addresses: str) -> str:
+    value = addresses.strip()
+    setting = db.get(models.Setting, ADDRESSES_KEY)
+    if not setting:
+        setting = models.Setting(key=ADDRESSES_KEY)
+        db.add(setting)
+    setting.value = value
+    db.commit()
+    db.refresh(setting)
+    return setting.value or ""

--- a/dancestudio/bot/handlers/menu.py
+++ b/dancestudio/bot/handlers/menu.py
@@ -27,6 +27,7 @@ from services import (
     fetch_slots,
     fetch_bookings,
     sync_user,
+    fetch_studio_addresses,
 )
 from services.api_client import Direction
 from states.booking import BookingStates
@@ -123,6 +124,22 @@ async def show_rules(callback: CallbackQuery) -> None:
     await _safe_edit_message(
         callback.message,
         texts.CANCEL_RULES,
+        reply_markup=main_menu_keyboard(),
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "addresses")
+async def show_addresses(callback: CallbackQuery) -> None:
+    try:
+        result = await fetch_studio_addresses()
+    except HTTPError:
+        await callback.answer(texts.API_ERROR, show_alert=True)
+        return
+    text = texts.studio_addresses(result.get("addresses"))
+    await _safe_edit_message(
+        callback.message,
+        text,
         reply_markup=main_menu_keyboard(),
     )
     await callback.answer()

--- a/dancestudio/bot/keyboards/main.py
+++ b/dancestudio/bot/keyboards/main.py
@@ -7,6 +7,7 @@ def main_menu_keyboard() -> InlineKeyboardMarkup:
             [InlineKeyboardButton(text="Записаться на занятие", callback_data="book_class")],
             [InlineKeyboardButton(text="Купить абонемент", callback_data="buy_subscription")],
             [InlineKeyboardButton(text="Мои записи", callback_data="my_bookings")],
+            [InlineKeyboardButton(text="Наши адреса", callback_data="addresses")],
             [InlineKeyboardButton(text="Правила отмены", callback_data="rules")],
         ]
     )

--- a/dancestudio/bot/services/__init__.py
+++ b/dancestudio/bot/services/__init__.py
@@ -6,6 +6,7 @@ from .api_client import (
     create_booking,
     create_subscription_payment,
     sync_user,
+    fetch_studio_addresses,
 )
 
 __all__ = [
@@ -16,4 +17,5 @@ __all__ = [
     "create_booking",
     "create_subscription_payment",
     "sync_user",
+    "fetch_studio_addresses",
 ]

--- a/dancestudio/bot/services/api_client.py
+++ b/dancestudio/bot/services/api_client.py
@@ -58,6 +58,10 @@ class Booking(TypedDict, total=False):
     reservation_expires_at: str | None
 
 
+class StudioAddresses(TypedDict, total=False):
+    addresses: str
+
+
 _settings = get_settings()
 
 
@@ -141,11 +145,19 @@ async def create_subscription_payment(
     return data
 
 
+async def fetch_studio_addresses() -> StudioAddresses:
+    data = await _get("/bot/addresses")
+    if isinstance(data, dict) and isinstance(data.get("addresses"), str):
+        return {"addresses": data["addresses"]}
+    return {"addresses": ""}
+
+
 __all__ = [
     "Product",
     "Direction",
     "Slot",
     "Booking",
+    "StudioAddresses",
     "fetch_products",
     "fetch_directions",
     "fetch_slots",
@@ -153,4 +165,5 @@ __all__ = [
     "create_booking",
     "sync_user",
     "create_subscription_payment",
+    "fetch_studio_addresses",
 ]

--- a/dancestudio/bot/utils/texts.py
+++ b/dancestudio/bot/utils/texts.py
@@ -29,6 +29,8 @@ FULL_NAME_SAVED = "Спасибо! Мы сохранили ваше ФИО."
 FULL_NAME_INVALID = "Пожалуйста, отправьте ФИО текстом."
 PAST_SLOT_ERROR = "Запись на прошедшее занятие недоступна."
 NO_SEATS_ERROR = "Свободных мест не осталось."
+ADDRESSES_TITLE = "Наши адреса:"
+NO_ADDRESSES = "Адреса пока не указаны."
 
 
 def _format_price(value: float | int | None) -> str:
@@ -107,6 +109,12 @@ def booking_payment_required(direction_name: str, starts_at: str, price: str | N
         parts.append(f"Стоимость: {price}")
     parts.append("Перейдите по ссылке ниже, чтобы оплатить занятие.")
     return "\n".join(parts)
+
+
+def studio_addresses(addresses: str | None) -> str:
+    if not addresses or not addresses.strip():
+        return NO_ADDRESSES
+    return f"{ADDRESSES_TITLE}\n{addresses.strip()}"
 
 
 def subscription_payment_details(product_name: str, price: str | None) -> str:


### PR DESCRIPTION
## Summary
- add a persistent setting, API endpoints, and migration for studio addresses editable from the admin panel
- update the admin settings screen to load and save studio addresses through the new API
- expose studio addresses to the bot API and show them behind a new "Наши адреса" menu button

## Testing
- poetry run pytest


------
https://chatgpt.com/codex/tasks/task_e_68e0200f894483299a8db87532cb6f5b