### PR TITLE
Shorten Alembic revision identifiers

### DIFF
--- a/dancestudio/backend/app/db/migrations/versions/0003_payment_confirmation_url.py
+++ b/dancestudio/backend/app/db/migrations/versions/0003_payment_confirmation_url.py
@@ -1,6 +1,6 @@
 """Add confirmation_url column to payments
 
-Revision ID: 0003_add_payment_confirmation_url
+Revision ID: 0003_payment_confirmation_url
 Revises: 0002_admin_login
 Create Date: 2024-05-26
 """
@@ -9,7 +9,7 @@ from alembic import op
 import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
-revision = "0003_add_payment_confirmation_url"
+revision = "0003_payment_confirmation_url"
 down_revision = "0002_admin_login"
 branch_labels = None
 depends_on = None

--- a/dancestudio/backend/app/db/migrations/versions/0004_add_settings_table.py
+++ b/dancestudio/backend/app/db/migrations/versions/0004_add_settings_table.py
@@ -1,7 +1,7 @@
 """Add settings table
 
 Revision ID: 0004_add_settings_table
-Revises: 0003_add_payment_confirmation_url
+Revises: 0003_payment_confirmation_url
 Create Date: 2024-06-06
 """
 
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "0004_add_settings_table"
-down_revision = "0003_add_payment_confirmation_url"
+down_revision = "0003_payment_confirmation_url"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- shorten the 0003 migration revision identifier so it fits within the alembic_version column limit
- update the subsequent migration to depend on the new identifier

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e023fd2a148329a53dc3d3e0808a6d