### PR TITLE
Handle slots with missing directions

### DIFF
--- a/dancestudio/backend/app/db/schemas/slot.py
+++ b/dancestudio/backend/app/db/schemas/slot.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel
 
 
 class ClassSlotBase(BaseModel):
-    direction_id: int
+    direction_id: int | None = None
     starts_at: datetime
     duration_min: int
     capacity: int
@@ -13,10 +13,11 @@ class ClassSlotBase(BaseModel):
 
 
 class ClassSlotCreate(ClassSlotBase):
-    pass
+    direction_id: int
 
 
 class ClassSlotUpdate(BaseModel):
+    direction_id: int | None = None
     starts_at: datetime | None = None
     duration_min: int | None = None
     capacity: int | None = None


### PR DESCRIPTION
## Summary
- allow class slot API schema to accept null direction IDs so listing slots stays stable after a direction update or removal
- keep creation payloads requiring a direction while permitting updates to change or drop the relation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e037a2d57c8329be1ad4619de6f195