### PR TITLE
Handle invalid payment URLs for Telegram inline buttons

### DIFF
--- a/dancestudio/bot/config.py
+++ b/dancestudio/bot/config.py
@@ -18,6 +18,7 @@ class BotSettings:
     api_base_url: str = _env("API_BASE_URL", "http://backend:8000/api/v1")
     timezone: str = _env("TIMEZONE", "Europe/Moscow")
     api_token: str = _env("BOT_API_TOKEN", "")
+    payment_fallback_url: str = _env("PAYMENT_FALLBACK_URL", "")
 
 
 def get_settings() -> BotSettings:

--- a/dancestudio/bot/utils/texts.py
+++ b/dancestudio/bot/utils/texts.py
@@ -31,6 +31,15 @@ PAST_SLOT_ERROR = "Запись на прошедшее занятие недо�
 NO_SEATS_ERROR = "Свободных мест не осталось."
 ADDRESSES_TITLE = "Наши адреса:"
 NO_ADDRESSES = "Адреса пока не указаны."
+PAYMENT_LINK_UNAVAILABLE_NOTE = "ссылка для оплаты недоступна"
+PAYMENT_LINK_UNAVAILABLE_MESSAGE = (
+    "Ссылка для оплаты сейчас недоступна.\n"
+    "Пожалуйста, свяжитесь с администратором, чтобы завершить оплату."
+)
+PAYMENT_LINK_UNAVAILABLE_ALERT = (
+    "Не удалось сформировать ссылку для оплаты. "
+    "Пожалуйста, свяжитесь с администратором."
+)
 
 
 def _format_price(value: float | int | None) -> str:
@@ -102,12 +111,21 @@ def booking_confirmed(direction_name: str, starts_at: str) -> str:
     )
 
 
-def booking_payment_required(direction_name: str, starts_at: str, price: str | None) -> str:
+def booking_payment_required(
+    direction_name: str,
+    starts_at: str,
+    price: str | None,
+    *,
+    link_available: bool = True,
+) -> str:
     clean_direction = direction_name or "Занятие"
     parts = [BOOKING_PAYMENT_REQUIRED, "", f"«{clean_direction}»", starts_at]
     if price:
         parts.append(f"Стоимость: {price}")
-    parts.append("Перейдите по ссылке ниже, чтобы оплатить занятие.")
+    if link_available:
+        parts.append("Перейдите по ссылке ниже, чтобы оплатить занятие.")
+    else:
+        parts.append(PAYMENT_LINK_UNAVAILABLE_MESSAGE)
     return "\n".join(parts)
 
 
@@ -117,12 +135,17 @@ def studio_addresses(addresses: str | None) -> str:
     return f"{ADDRESSES_TITLE}\n{addresses.strip()}"
 
 
-def subscription_payment_details(product_name: str, price: str | None) -> str:
+def subscription_payment_details(
+    product_name: str, price: str | None, *, link_available: bool = True
+) -> str:
     clean_name = product_name or "Абонемент"
     parts = [SUBSCRIPTION_PAYMENT_REQUIRED, "", f"«{clean_name}»"]
     if price:
         parts.append(f"Стоимость: {price}")
-    parts.append("Перейдите по ссылке ниже, чтобы оплатить.")
+    if link_available:
+        parts.append("Перейдите по ссылке ниже, чтобы оплатить.")
+    else:
+        parts.append(PAYMENT_LINK_UNAVAILABLE_MESSAGE)
     return "\n".join(parts)
 
 

--- a/dancestudio/deploy/env/.env.example
+++ b/dancestudio/deploy/env/.env.example
@@ -23,6 +23,7 @@ TELEGRAM_ADMIN_IDS=
 
 # Bot
 API_BASE_URL=http://backend:8000/api/v1
+PAYMENT_FALLBACK_URL=
 
 # Admin
 # Укажите учетные данные администратора, которые будут созданы при старте


### PR DESCRIPTION
## Summary
- sanitize payment URLs before building inline keyboard buttons and fall back to a configurable link when needed
- update booking/subscription messages to explain when a payment link is unavailable
- add a PAYMENT_FALLBACK_URL setting to document how to configure a safe default payment link

## Testing
- pytest dancestudio/bot

------
https://chatgpt.com/codex/tasks/task_e_68e03c558b7483299296500228051142