### PR TITLE
Fix bot API client base URL path handling

### DIFF
--- a/dancestudio/bot/services/api_client.py
+++ b/dancestudio/bot/services/api_client.py
@@ -76,16 +76,24 @@ class StudioAddresses(TypedDict, total=False):
 _settings = get_settings()
 
 
+def _request_path(path: str) -> str:
+    """Return a path relative to the configured API base URL."""
+
+    if path.startswith("http://") or path.startswith("https://"):
+        return path
+    return path.lstrip("/")
+
+
 async def _get(path: str, params: dict[str, Any] | None = None) -> Any:
     async with httpx.AsyncClient(base_url=_settings.api_base_url, timeout=10.0) as client:
-        response = await client.get(path, params=params, headers=_headers())
+        response = await client.get(_request_path(path), params=params, headers=_headers())
         response.raise_for_status()
         return response.json()
 
 
 async def _post(path: str, json: dict[str, Any]) -> Any:
     async with httpx.AsyncClient(base_url=_settings.api_base_url, timeout=10.0) as client:
-        response = await client.post(path, json=json, headers=_headers())
+        response = await client.post(_request_path(path), json=json, headers=_headers())
         response.raise_for_status()
         return response.json()
 


### PR DESCRIPTION
## Summary
- ensure bot API client requests remain relative to the configured API base URL path
- add a helper that normalizes request paths for both GET and POST helpers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e04c730ed88329a2b59fa0a0eff30f