### PR TITLE
Fix bot config imports

### DIFF
--- a/dancestudio/bot/app.py
+++ b/dancestudio/bot/app.py
@@ -5,7 +5,7 @@ from aiogram.client.default import DefaultBotProperties
 from aiogram.enums import ParseMode
 from aiogram.fsm.storage.memory import MemoryStorage
 from aiogram.types import BotCommand
-from config import get_settings
+from .config import get_settings
 from handlers import menu
 from middlewares.logging import LoggingMiddleware
 

--- a/dancestudio/bot/handlers/menu.py
+++ b/dancestudio/bot/handlers/menu.py
@@ -12,7 +12,7 @@ from aiogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMar
 from httpx import HTTPError
 from urllib.parse import urlparse
 
-from config import get_settings
+from ..config import get_settings
 from keyboards import (
     directions_keyboard,
     product_actions_keyboard,

--- a/dancestudio/bot/services/api_client.py
+++ b/dancestudio/bot/services/api_client.py
@@ -5,7 +5,7 @@ from typing import Any, TypedDict
 
 import httpx
 
-from config import get_settings
+from ..config import get_settings
 
 
 class Product(TypedDict, total=False):
@@ -76,16 +76,24 @@ class StudioAddresses(TypedDict, total=False):
 _settings = get_settings()
 
 
+def _request_path(path: str) -> str:
+    """Return a path relative to the configured API base URL."""
+
+    if path.startswith("http://") or path.startswith("https://"):
+        return path
+    return path.lstrip("/")
+
+
 async def _get(path: str, params: dict[str, Any] | None = None) -> Any:
     async with httpx.AsyncClient(base_url=_settings.api_base_url, timeout=10.0) as client:
-        response = await client.get(path, params=params, headers=_headers())
+        response = await client.get(_request_path(path), params=params, headers=_headers())
         response.raise_for_status()
         return response.json()
 
 
 async def _post(path: str, json: dict[str, Any]) -> Any:
     async with httpx.AsyncClient(base_url=_settings.api_base_url, timeout=10.0) as client:
-        response = await client.post(path, json=json, headers=_headers())
+        response = await client.post(_request_path(path), json=json, headers=_headers())
         response.raise_for_status()
         return response.json()
 


### PR DESCRIPTION
## Summary
- update bot modules to load settings from the bot-specific config module
- ensure the API client, handlers, and app use the correct bot configuration

## Testing
- pytest dancestudio/backend/tests/test_bot_api.py

------
https://chatgpt.com/codex/tasks/task_e_68e04c730ed88329a2b59fa0a0eff30f