### PR TITLE
Add package marker for dancestudio namespace

### DIFF
--- a/dancestudio/__init__.py
+++ b/dancestudio/__init__.py
@@ -1,0 +1,4 @@
+"""Top-level package for the Dance Studio project."""
+
+# This file enables imports that rely on the ``dancestudio`` namespace, such as
+# ``dancestudio.bot`` and ``dancestudio.backend``.


### PR DESCRIPTION
## Summary
- add an __init__ file at the repository's dancestudio root so Python treats it as a package
- document that the file enables imports of the subpackages used by the bot

## Testing
- python - <<'PY'
import importlib
import sys
print('sys.path[0]:', sys.path[0])
importlib.import_module('dancestudio.bot')
print('import succeeded')
PY

------
https://chatgpt.com/codex/tasks/task_e_68e051ed03a88329b0576342d1623c79