### PR TITLE
Handle bot imports without dancestudio package root

### DIFF
--- a/dancestudio/bot/app.py
+++ b/dancestudio/bot/app.py
@@ -1,13 +1,44 @@
 import asyncio
 import logging
+from pathlib import Path
+from typing import Iterable
+
 from aiogram import Bot, Dispatcher
 from aiogram.client.default import DefaultBotProperties
 from aiogram.enums import ParseMode
 from aiogram.fsm.storage.memory import MemoryStorage
 from aiogram.types import BotCommand
-from dancestudio.bot.config import get_settings
-from dancestudio.bot.handlers import menu
-from dancestudio.bot.middlewares.logging import LoggingMiddleware
+
+
+def _ensure_standalone_imports(paths: Iterable[Path]) -> None:
+    """Ensure local package imports work when run outside the project root.
+
+    The bot container copies only the contents of ``dancestudio/bot`` into
+    ``/app``.  In that environment the ``dancestudio`` package is absent, which
+    prevents ``from dancestudio.bot import ...`` imports from working.  We fall
+    back to importing modules relative to the current file by temporarily
+    extending ``sys.path`` with the provided directories.
+    """
+
+    import sys
+
+    for path in paths:
+        resolved = str(path.resolve())
+        if resolved not in sys.path:
+            sys.path.insert(0, resolved)
+
+
+try:  # pragma: no cover - executed depending on deployment layout
+    from dancestudio.bot.config import get_settings
+    from dancestudio.bot.handlers import menu
+    from dancestudio.bot.middlewares.logging import LoggingMiddleware
+except ModuleNotFoundError as exc:  # pragma: no cover - fallback for Docker image
+    if exc.name and not exc.name.startswith("dancestudio"):
+        raise
+    _ensure_standalone_imports([Path(__file__).resolve().parent])
+    from config import get_settings  # type: ignore[no-redef]
+    from handlers import menu  # type: ignore[no-redef]
+    from middlewares.logging import LoggingMiddleware  # type: ignore[no-redef]
 
 logging.basicConfig(level=logging.INFO)
 

--- a/dancestudio/bot/handlers/menu.py
+++ b/dancestudio/bot/handlers/menu.py
@@ -12,29 +12,55 @@ from aiogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMar
 from httpx import HTTPError
 from urllib.parse import urlparse
 
-from dancestudio.bot.config import get_settings
-from dancestudio.bot.keyboards import (
-    directions_keyboard,
-    product_actions_keyboard,
-    products_keyboard,
-    main_menu_keyboard,
-    slots_keyboard,
-    slot_actions_keyboard,
-)
-from dancestudio.bot.services import (
-    create_booking,
-    create_subscription_payment,
-    fetch_directions,
-    fetch_products,
-    fetch_slots,
-    fetch_bookings,
-    fetch_subscriptions,
-    sync_user,
-    fetch_studio_addresses,
-)
-from dancestudio.bot.services.api_client import Direction
+try:  # pragma: no cover - executed depending on import layout
+    from dancestudio.bot.config import get_settings
+    from dancestudio.bot.keyboards import (
+        directions_keyboard,
+        product_actions_keyboard,
+        products_keyboard,
+        main_menu_keyboard,
+        slots_keyboard,
+        slot_actions_keyboard,
+    )
+    from dancestudio.bot.services import (
+        create_booking,
+        create_subscription_payment,
+        fetch_directions,
+        fetch_products,
+        fetch_slots,
+        fetch_bookings,
+        fetch_subscriptions,
+        sync_user,
+        fetch_studio_addresses,
+    )
+    from dancestudio.bot.services.api_client import Direction
+    from dancestudio.bot.utils import texts
+except ModuleNotFoundError as exc:  # pragma: no cover - fallback for Docker image
+    if exc.name and not exc.name.startswith("dancestudio"):
+        raise
+    from config import get_settings  # type: ignore[no-redef]
+    from keyboards import (  # type: ignore[no-redef]
+        directions_keyboard,
+        product_actions_keyboard,
+        products_keyboard,
+        main_menu_keyboard,
+        slots_keyboard,
+        slot_actions_keyboard,
+    )
+    from services import (  # type: ignore[no-redef]
+        create_booking,
+        create_subscription_payment,
+        fetch_directions,
+        fetch_products,
+        fetch_slots,
+        fetch_bookings,
+        fetch_subscriptions,
+        sync_user,
+        fetch_studio_addresses,
+    )
+    from services.api_client import Direction  # type: ignore[no-redef]
+    from utils import texts  # type: ignore[no-redef]
 from states.booking import BookingStates
-from dancestudio.bot.utils import texts
 
 router = Router()
 _settings = get_settings()

--- a/dancestudio/bot/services/api_client.py
+++ b/dancestudio/bot/services/api_client.py
@@ -5,7 +5,12 @@ from typing import Any, TypedDict
 
 import httpx
 
-from dancestudio.bot.config import get_settings
+try:  # pragma: no cover - executed depending on import layout
+    from dancestudio.bot.config import get_settings
+except ModuleNotFoundError as exc:  # pragma: no cover - fallback for Docker image
+    if exc.name and not exc.name.startswith("dancestudio"):
+        raise
+    from config import get_settings  # type: ignore[no-redef]
 
 
 class Product(TypedDict, total=False):


### PR DESCRIPTION
## Summary
- add a helper to extend sys.path when the dancestudio package root is unavailable
- update bot modules to fall back to local imports when the package name is missing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e05509ff4c832992d6813febab5fd8