### PR TITLE
Add date-based filtering to admin schedule view

### DIFF
--- a/dancestudio/admin-frontend/package.json
+++ b/dancestudio/admin-frontend/package.json
@@ -11,6 +11,7 @@
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.3",
     "@mui/material": "^5.15.10",
+    "@mui/x-date-pickers": "^6.17.1",
     "@tanstack/react-query": "^5.24.7",
     "axios": "^1.6.7",
     "react": "^18.2.0",


### PR DESCRIPTION
## Summary
- add a date picker and quick filters so admins can browse the schedule day by day
- pass the selected date to the slots API and prefill new classes with that day
- show cancellation controls and loading state improvements in the schedule grid

## Testing
- not run (npm registry access denied in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e0600d5f7c8329bd222bb72ece208f