### PR TITLE
Add admin class cancellation notifications

### DIFF
--- a/dancestudio/admin-frontend/src/pages/Schedule.tsx
+++ b/dancestudio/admin-frontend/src/pages/Schedule.tsx
@@ -64,6 +64,7 @@ const SchedulePage = () => {
   const [dialogOpen, setDialogOpen] = useState(false)
   const [editingSlot, setEditingSlot] = useState<Slot | null>(null)
   const [selectedDate, setSelectedDate] = useState<Dayjs | null>(dayjs())
+  const [cancelingSlotId, setCancelingSlotId] = useState<number | null>(null)
 
   const directionsQuery = useQuery({
     queryKey: ['directions'],
@@ -160,7 +161,7 @@ const SchedulePage = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['slots'] })
-    }
+    },
   })
 
   const cancelMutation = useMutation({
@@ -170,6 +171,9 @@ const SchedulePage = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['slots'] })
+    },
+    onSettled: () => {
+      setCancelingSlotId(null)
     }
   })
 
@@ -196,6 +200,7 @@ const SchedulePage = () => {
       return
     }
     if (window.confirm('Отменить это занятие?')) {
+      setCancelingSlotId(slot.id)
       cancelMutation.mutate(slot.id)
     }
   }
@@ -260,7 +265,9 @@ const SchedulePage = () => {
             disabled={params.row.status === 'canceled' || cancelMutation.isPending}
             onClick={() => handleCancel(params.row)}
           >
-            Отменить
+            {cancelMutation.isPending && cancelingSlotId === params.row.id
+              ? 'Отмена...'
+              : 'Отменить'}
           </Button>
           <Button size="small" color="error" onClick={() => handleDelete(params.row)}>
             Удалить

--- a/dancestudio/backend/app/services/__init__.py
+++ b/dancestudio/backend/app/services/__init__.py
@@ -5,6 +5,7 @@ from . import (
     google_sheets,
     settings_service,
     subscription_service,
+    notification_service,
 )
 __all__ = [
     "booking_service",
@@ -13,4 +14,5 @@ __all__ = [
     "google_sheets",
     "settings_service",
     "subscription_service",
+    "notification_service",
 ]

--- a/dancestudio/backend/app/services/notification_service.py
+++ b/dancestudio/backend/app/services/notification_service.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import httpx
+
+from ..config import get_settings
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class SlotCancellationNotification:
+    tg_id: int
+    message: str
+
+
+def build_slot_cancellation_message(
+    *, direction_name: str | None, starts_at: datetime
+) -> str:
+    settings = get_settings()
+    timezone = ZoneInfo(settings.timezone)
+    local_dt = starts_at.astimezone(timezone)
+    direction_label = direction_name or "Занятие"
+    formatted_dt = local_dt.strftime("%d.%m.%Y %H:%M")
+    return (
+        f"Занятие «{direction_label}» {formatted_dt} отменено. "
+        "Мы вернули вам одно занятие."
+    )
+
+
+def notify_slot_cancellation(notifications: list[SlotCancellationNotification]) -> None:
+    if not notifications:
+        return
+
+    settings = get_settings()
+    token = settings.telegram_bot_token
+    if not token:
+        logger.warning(
+            "Telegram bot token is not configured; skipping slot cancellation notifications"
+        )
+        return
+
+    api_url = f"https://api.telegram.org/bot{token}/sendMessage"
+    with httpx.Client(timeout=10) as client:
+        for notification in notifications:
+            try:
+                response = client.post(
+                    api_url,
+                    json={
+                        "chat_id": notification.tg_id,
+                        "text": notification.message,
+                        "disable_web_page_preview": True,
+                    },
+                )
+                response.raise_for_status()
+            except httpx.HTTPError:
+                logger.exception(
+                    "Failed to send slot cancellation notification",
+                    extra={"tg_id": notification.tg_id},
+                )


### PR DESCRIPTION
## Summary
- add a dedicated cancel action in the admin schedule grid with a loading state
- implement a Telegram notification service and trigger it from class cancellations
- extend the schedule service test suite to cover notification delivery

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e069a4dc7883298abbb7c465ee9a86