### PR TITLE
Allow rebooking and show remaining seats

### DIFF
--- a/dancestudio/backend/app/db/schemas/slot.py
+++ b/dancestudio/backend/app/db/schemas/slot.py
@@ -28,6 +28,8 @@ class ClassSlotUpdate(BaseModel):
 
 class ClassSlot(ClassSlotBase):
     id: int
+    booked_seats: int | None = None
+    available_seats: int | None = None
 
     class Config:
         from_attributes = True

--- a/dancestudio/backend/tests/test_booking.py
+++ b/dancestudio/backend/tests/test_booking.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta, timezone
 import pytest
+from app.core.constants import PAYMENT_TIMEOUT_REASON, RESERVATION_PAYMENT_TIMEOUT, SYSTEM_ACTOR
 from app.db import models
 from app.services import booking_service
 
@@ -37,3 +38,39 @@ def test_booking_capacity_limit(db_session):
     booking_service.book_class(db_session, user1, slot)
     with pytest.raises(booking_service.BookingError):
         booking_service.book_class(db_session, user2, slot)
+
+
+def test_rebook_after_cancellation(db_session):
+    slot = create_slot(db_session, capacity=2)
+    user = create_user(db_session, 1)
+
+    booking = booking_service.book_class(db_session, user, slot)
+    assert booking.status in {models.BookingStatus.reserved, models.BookingStatus.confirmed}
+
+    canceled = booking_service.cancel_booking(db_session, booking, actor="test")
+    assert canceled.status == models.BookingStatus.canceled
+
+    new_booking = booking_service.book_class(db_session, user, slot)
+    assert new_booking.id == booking.id
+    assert new_booking.status in {models.BookingStatus.reserved, models.BookingStatus.confirmed}
+
+
+def test_rebook_after_reservation_timeout(db_session):
+    slot = create_slot(db_session, capacity=2)
+    user = create_user(db_session, 1)
+
+    booking = booking_service.book_class(db_session, user, slot)
+    assert booking.status == models.BookingStatus.reserved
+
+    booking.created_at = datetime.now(timezone.utc) - RESERVATION_PAYMENT_TIMEOUT - timedelta(minutes=1)
+    booking.status = models.BookingStatus.canceled
+    booking.canceled_at = datetime.now(timezone.utc)
+    booking.canceled_by = SYSTEM_ACTOR
+    booking.cancellation_reason = PAYMENT_TIMEOUT_REASON
+    db_session.commit()
+
+    assert booking.status == models.BookingStatus.canceled
+
+    new_booking = booking_service.book_class(db_session, user, slot)
+    assert new_booking.id == booking.id
+    assert new_booking.status == models.BookingStatus.reserved

--- a/dancestudio/bot/utils/texts.py
+++ b/dancestudio/bot/utils/texts.py
@@ -94,7 +94,16 @@ def no_slots(name: str) -> str:
 def slot_details(direction_name: str, slot: Mapping[str, object], starts_at: str) -> str:
     clean_direction = direction_name or "Занятие"
     duration = slot.get("duration_min", 0)
-    capacity = slot.get("capacity", 0)
+    capacity_raw = slot.get("capacity")
+    try:
+        capacity = int(capacity_raw)
+    except (TypeError, ValueError):
+        capacity = 0
+    available_raw = slot.get("available_seats")
+    try:
+        available = int(available_raw)
+    except (TypeError, ValueError):
+        available = None
     price = _format_price(slot.get("price_single_visit"))
     allow_subscription = slot.get("allow_subscription", False)
     status = slot.get("status", "scheduled")
@@ -102,7 +111,9 @@ def slot_details(direction_name: str, slot: Mapping[str, object], starts_at: str
     lines = [f"{clean_direction}", starts_at]
     if duration:
         lines.append(f"Длительность: {duration} мин")
-    if capacity:
+    if available is not None and capacity:
+        lines.append(f"Свободно: {max(available, 0)}/{capacity}")
+    elif capacity:
         lines.append(f"Мест: {capacity}")
     if price:
         lines.append(f"Разовое посещение: {price}")


### PR DESCRIPTION
## Summary
- allow clients to book the same slot again after a cancellation or expired reservation
- expose active booking counts in slot responses so the bot can display remaining seats
- show free/total seats in the bot slot details and cover the new behavior with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e06eafeb808329a36bfe0a0c58986a