### PR TITLE
Fix cancellation credit for unpaid bookings

### DIFF
--- a/dancestudio/backend/app/services/booking_service.py
+++ b/dancestudio/backend/app/services/booking_service.py
@@ -125,11 +125,13 @@ def cancel_booking(db: Session, booking: models.Booking, actor: str) -> models.B
         return booking
     if booking.status not in [BookingStatus.confirmed, BookingStatus.reserved]:
         raise BookingError("Cannot cancel")
-    grant_class_credit(
-        db,
-        user_id=booking.user_id,
-        slot_direction_id=slot.direction_id,
-    )
+
+    if booking.status == BookingStatus.confirmed:
+        grant_class_credit(
+            db,
+            user_id=booking.user_id,
+            slot_direction_id=slot.direction_id,
+        )
     booking.status = BookingStatus.canceled
     booking.canceled_at = now
     booking.canceled_by = actor


### PR DESCRIPTION
## Summary
- prevent issuing cancellation credits when a reserved booking is canceled, avoiding refunds for unpaid classes

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e070b7e97083298e4939c604f5fe7f