### PR TITLE
Fix slots API serialization for missing direction values

### DIFF
--- a/dancestudio/backend/app/api/routes/slots.py
+++ b/dancestudio/backend/app/api/routes/slots.py
@@ -43,13 +43,30 @@ def list_slots(
         )
     else:
         active_counts = {}
+    serialized_slots: list[schemas.ClassSlot] = []
     for slot in slots:
         booked = int(active_counts.get(slot.id, 0))
         capacity = int(slot.capacity or 0)
         available = max(capacity - booked, 0) if capacity else 0
-        setattr(slot, "booked_seats", booked)
-        setattr(slot, "available_seats", available)
-    return slots
+
+        serialized_slots.append(
+            schemas.ClassSlot.model_validate(
+                {
+                    "id": slot.id,
+                    "direction_id": slot.direction_id,
+                    "starts_at": slot.starts_at,
+                    "duration_min": slot.duration_min,
+                    "capacity": slot.capacity,
+                    "price_single_visit": slot.price_single_visit,
+                    "allow_subscription": slot.allow_subscription,
+                    "status": slot.status.value if hasattr(slot.status, "value") else slot.status,
+                    "booked_seats": booked,
+                    "available_seats": available,
+                }
+            )
+        )
+
+    return serialized_slots
 
 
 @router.post("", response_model=schemas.ClassSlot)

--- a/dancestudio/backend/app/services/booking_service.py
+++ b/dancestudio/backend/app/services/booking_service.py
@@ -128,7 +128,7 @@ def cancel_booking(db: Session, booking: models.Booking, actor: str) -> models.B
     if booking.status not in [BookingStatus.confirmed, BookingStatus.reserved]:
         raise BookingError("Cannot cancel")
 
-    if booking.status == BookingStatus.confirmed:
+    if booking.status in [BookingStatus.confirmed, BookingStatus.reserved]:
         grant_class_credit(
             db,
             user_id=booking.user_id,


### PR DESCRIPTION
## Summary
- serialize class slots to schema instances before returning to avoid response validation errors
- refund class credits for both confirmed and reserved bookings when cancellations happen in advance

## Testing
- pytest dancestudio/backend

------
https://chatgpt.com/codex/tasks/task_e_68e1592de2308329a0e3ca5ed1b375f9