### PR TITLE
Add migration for telegram payment provider

### DIFF
--- a/dancestudio/backend/app/db/migrations/versions/0005_extend_payment_provider_enum.py
+++ b/dancestudio/backend/app/db/migrations/versions/0005_extend_payment_provider_enum.py
@@ -1,0 +1,61 @@
+"""Add stub and telegram providers to payment enum
+
+Revision ID: 0005_extend_payment_provider_enum
+Revises: 0004_add_settings_table
+Create Date: 2025-10-06
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "0005_extend_payment_provider_enum"
+down_revision = "0004_add_settings_table"
+branch_labels = None
+depends_on = None
+
+
+OLD_PAYMENT_PROVIDERS = (
+    "yookassa",
+    "stripe",
+    "tinkoff",
+    "cloudpayments",
+)
+
+NEW_PAYMENT_PROVIDERS = OLD_PAYMENT_PROVIDERS + (
+    "stub",
+    "telegram",
+)
+
+
+def upgrade() -> None:
+    for provider in NEW_PAYMENT_PROVIDERS[len(OLD_PAYMENT_PROVIDERS) :]:
+        op.execute(
+            sa.text(
+                "ALTER TYPE paymentprovider ADD VALUE IF NOT EXISTS :provider"
+            ).bindparams(provider=provider)
+        )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text(
+            "UPDATE payments SET provider = 'yookassa' "
+            "WHERE provider IN ('stub', 'telegram')"
+        )
+    )
+
+    payment_provider_old = postgresql.ENUM(
+        *OLD_PAYMENT_PROVIDERS,
+        name="paymentprovider_old",
+    )
+    payment_provider_old.create(op.get_bind(), checkfirst=False)
+
+    op.execute(
+        "ALTER TABLE payments ALTER COLUMN provider TYPE paymentprovider_old "
+        "USING provider::text::paymentprovider_old"
+    )
+
+    op.execute("DROP TYPE paymentprovider")
+    op.execute("ALTER TYPE paymentprovider_old RENAME TO paymentprovider")


### PR DESCRIPTION
## Summary
- add an Alembic migration that expands the paymentprovider enum with stub and telegram values
- ensure downgrade recreates the original enum definition

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e323d04d708329adc7843c69f664f8