### PR TITLE
Shorten migration revision id

### DIFF
--- a/dancestudio/backend/app/db/migrations/versions/0005_extend_payment_provider.py
+++ b/dancestudio/backend/app/db/migrations/versions/0005_extend_payment_provider.py
@@ -1,6 +1,6 @@
 """Add stub and telegram providers to payment enum
 
-Revision ID: 0005_extend_payment_provider_enum
+Revision ID: 0005_extend_payment_provider
 Revises: 0004_add_settings_table
 Create Date: 2025-10-06
 """
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
-revision = "0005_extend_payment_provider_enum"
+revision = "0005_extend_payment_provider"
 down_revision = "0004_add_settings_table"
 branch_labels = None
 depends_on = None


### PR DESCRIPTION
## Summary
- shorten the Alembic revision identifier for the 0005 migration to fit within the alembic_version column length

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e390d526188329bf9f089c3976f837