### PR TITLE
Add profile prompts, manual subscription issuance, and address media uploads

### DIFF
--- a/dancestudio/admin-frontend/src/pages/Settings.tsx
+++ b/dancestudio/admin-frontend/src/pages/Settings.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { ChangeEvent, useEffect, useRef, useState } from 'react'
 import {
   Box,
   TextField,
@@ -16,11 +16,26 @@ type SettingsForm = {
   addresses: string
 }
 
+type AddressMedia = {
+  id: number
+  url: string
+  media_type: 'image' | 'video'
+  filename: string
+}
+
 type StudioAddresses = {
   addresses: string
+  media: AddressMedia[]
+}
+
+type SettingsUpdatePayload = SettingsForm & {
+  media_ids: number[]
 }
 
 const SettingsPage = () => {
+  const [media, setMedia] = useState<AddressMedia[]>([])
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
+
   const { register, handleSubmit, reset } = useForm<SettingsForm>({
     defaultValues: {
       addresses: ''
@@ -38,21 +53,59 @@ const SettingsPage = () => {
   useEffect(() => {
     if (addressesQuery.data) {
       reset({ addresses: addressesQuery.data.addresses })
+      setMedia(addressesQuery.data.media ?? [])
     }
   }, [addressesQuery.data, reset])
 
   const updateMutation = useMutation({
-    mutationFn: async (payload: SettingsForm) => {
+    mutationFn: async (payload: SettingsUpdatePayload) => {
       const { data } = await apiClient.put<StudioAddresses>('/settings/addresses', payload)
       return data
     },
     onSuccess: (data) => {
       reset({ addresses: data.addresses })
+      setMedia(data.media ?? [])
     }
   })
 
+  const uploadMutation = useMutation({
+    mutationFn: async (files: FileList) => {
+      const formData = new FormData()
+      Array.from(files).forEach((file) => {
+        formData.append('files', file)
+      })
+      const { data } = await apiClient.post<AddressMedia[]>(
+        '/settings/addresses/media',
+        formData,
+        {
+          headers: { 'Content-Type': 'multipart/form-data' }
+        }
+      )
+      return data
+    },
+    onSuccess: (items) => {
+      setMedia((prev) => [...prev, ...items])
+    }
+  })
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const files = event.target.files
+    if (!files || files.length === 0) {
+      return
+    }
+    uploadMutation.mutate(files)
+    event.target.value = ''
+  }
+
+  const handleRemoveMedia = (id: number) => {
+    setMedia((prev) => prev.filter((item) => item.id !== id))
+  }
+
   const onSubmit = (values: SettingsForm) => {
-    updateMutation.mutate(values)
+    updateMutation.mutate({
+      addresses: values.addresses,
+      media_ids: media.map((item) => item.id)
+    })
   }
 
   if (addressesQuery.isLoading) {
@@ -83,6 +136,59 @@ const SettingsPage = () => {
           minRows={4}
           {...register('addresses')}
         />
+        <Stack spacing={1}>
+          <Typography variant="subtitle1">Фото и видео</Typography>
+          {uploadMutation.isError && (
+            <Alert severity="error">Не удалось загрузить файлы. Попробуйте ещё раз.</Alert>
+          )}
+          <Stack direction="row" spacing={2} flexWrap="wrap">
+            {media.map((item) => (
+              <Box key={item.id} width={160}>
+                {item.media_type === 'video' ? (
+                  <Box component="video" src={item.url} controls width="100%" />
+                ) : (
+                  <Box
+                    component="img"
+                    src={item.url}
+                    alt={item.filename}
+                    sx={{ width: '100%', height: 120, objectFit: 'cover', borderRadius: 1 }}
+                  />
+                )}
+                <Typography variant="caption" noWrap title={item.filename}>
+                  {item.filename}
+                </Typography>
+                <Button size="small" color="secondary" onClick={() => handleRemoveMedia(item.id)}>
+                  Удалить
+                </Button>
+              </Box>
+            ))}
+            {media.length === 0 && (
+              <Typography variant="body2" color="text.secondary">
+                Добавьте фото или видео, чтобы показать студию ученикам.
+              </Typography>
+            )}
+          </Stack>
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            accept="image/*,video/*"
+            hidden
+            onChange={handleFileChange}
+          />
+          <Stack direction="row" spacing={1} alignItems="center">
+            <Button
+              variant="outlined"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={uploadMutation.isPending}
+            >
+              {uploadMutation.isPending ? 'Загрузка...' : 'Загрузить файлы'}
+            </Button>
+            <Typography variant="caption" color="text.secondary">
+              Удалённые файлы исчезнут после сохранения настроек.
+            </Typography>
+          </Stack>
+        </Stack>
         <Button type="submit" variant="contained" disabled={updateMutation.isPending}>
           {updateMutation.isPending ? 'Сохранение...' : 'Сохранить'}
         </Button>

--- a/dancestudio/admin-frontend/src/pages/Users.tsx
+++ b/dancestudio/admin-frontend/src/pages/Users.tsx
@@ -1,6 +1,20 @@
-import { useQuery } from '@tanstack/react-query'
+import { useState } from 'react'
+import { useQuery, useMutation } from '@tanstack/react-query'
+import { useForm } from 'react-hook-form'
+import {
+  Alert,
+  CircularProgress,
+  Box,
+  Stack,
+  TextField,
+  Button,
+  Typography,
+  Paper,
+  List,
+  ListItemButton,
+  ListItemText
+} from '@mui/material'
 import { apiClient } from '../api/client'
-import { Alert, CircularProgress, Box } from '@mui/material'
 import { DataGrid, GridColDef } from '@mui/x-data-grid'
 
 interface User {
@@ -9,6 +23,11 @@ interface User {
   tg_id: number
   age?: number
   phone?: string
+}
+
+interface ManualSubscriptionForm {
+  classesCount: number
+  validityDays?: number
 }
 
 const columns: GridColDef<User>[] = [
@@ -20,12 +39,60 @@ const columns: GridColDef<User>[] = [
 ]
 
 const UsersPage = () => {
+  const [search, setSearch] = useState('')
+  const [selectedUser, setSelectedUser] = useState<User | null>(null)
+
   const { data, isLoading, error } = useQuery({
     queryKey: ['users'],
     queryFn: async () => {
       const response = await apiClient.get<User[]>('/users')
       return response.data
     }
+  })
+
+  const searchQuery = useQuery({
+    queryKey: ['user-search', search],
+    queryFn: async () => {
+      const response = await apiClient.get<User[]>('/users/search', {
+        params: { q: search }
+      })
+      return response.data
+    },
+    enabled: search.trim().length >= 2
+  })
+
+  const {
+    register,
+    handleSubmit,
+    reset: resetSubscriptionForm
+  } = useForm<ManualSubscriptionForm>({
+    defaultValues: { classesCount: 1, validityDays: 90 }
+  })
+
+  const grantMutation = useMutation({
+    mutationFn: async (values: ManualSubscriptionForm) => {
+      if (!selectedUser) {
+        throw new Error('Пользователь не выбран')
+      }
+      const payload: { classes_count: number; validity_days?: number } = {
+        classes_count: values.classesCount
+      }
+      if (values.validityDays && values.validityDays > 0) {
+        payload.validity_days = values.validityDays
+      }
+      const { data: subscription } = await apiClient.post(
+        `/users/${selectedUser.id}/manual-subscription`,
+        payload
+      )
+      return subscription
+    },
+    onSuccess: () => {
+      resetSubscriptionForm({ classesCount: 1, validityDays: 90 })
+    }
+  })
+
+  const onGrant = handleSubmit((values) => {
+    grantMutation.mutate(values)
   })
 
   if (isLoading) {
@@ -41,9 +108,90 @@ const UsersPage = () => {
   }
 
   return (
-    <Box height={400}>
-      <DataGrid rows={data ?? []} columns={columns} disableRowSelectionOnClick />
-    </Box>
+    <Stack spacing={4}>
+      <Stack spacing={2}>
+        <Typography variant="h6">Выдать абонемент вручную</Typography>
+        <Stack spacing={1} maxWidth={480}>
+          <TextField
+            label="Поиск по ФИО"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            helperText="Введите минимум 2 символа"
+          />
+          {search.trim().length >= 2 && (
+            <Paper variant="outlined">
+              {searchQuery.isFetching && (
+                <Typography variant="body2" px={2} py={1} color="text.secondary">
+                  Поиск...
+                </Typography>
+              )}
+              {!searchQuery.isFetching && (searchQuery.data?.length ?? 0) === 0 && (
+                <Typography variant="body2" px={2} py={1} color="text.secondary">
+                  Пользователи не найдены
+                </Typography>
+              )}
+              <List dense disablePadding>
+                {searchQuery.data?.map((user) => (
+                  <ListItemButton
+                    key={user.id}
+                    selected={selectedUser?.id === user.id}
+                    onClick={() => setSelectedUser(user)}
+                  >
+                    <ListItemText
+                      primary={user.full_name || `ID ${user.id}`}
+                      secondary={`Telegram ID: ${user.tg_id}`}
+                    />
+                  </ListItemButton>
+                ))}
+              </List>
+            </Paper>
+          )}
+        </Stack>
+        {selectedUser && (
+          <Typography variant="body2" color="text.secondary">
+            Выбран пользователь: {selectedUser.full_name || `ID ${selectedUser.id}`} · Telegram ID:{' '}
+            {selectedUser.tg_id}
+          </Typography>
+        )}
+        <Box component="form" onSubmit={onGrant} maxWidth={480}>
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems="flex-end">
+            <TextField
+              label="Количество занятий"
+              type="number"
+              inputProps={{ min: 1 }}
+              {...register('classesCount', {
+                valueAsNumber: true,
+                min: 1
+              })}
+            />
+            <TextField
+              label="Срок действия (дней)"
+              type="number"
+              inputProps={{ min: 1 }}
+              {...register('validityDays', {
+                setValueAs: (value) => (value === '' ? undefined : Number(value))
+              })}
+            />
+            <Button
+              type="submit"
+              variant="contained"
+              disabled={!selectedUser || grantMutation.isPending}
+            >
+              {grantMutation.isPending ? 'Выдаём...' : 'Выдать'}
+            </Button>
+          </Stack>
+        </Box>
+        {grantMutation.isError && (
+          <Alert severity="error">Не удалось выдать абонемент. Попробуйте ещё раз.</Alert>
+        )}
+        {grantMutation.isSuccess && !grantMutation.isPending && (
+          <Alert severity="success">Абонемент успешно выдан.</Alert>
+        )}
+      </Stack>
+      <Box height={400}>
+        <DataGrid rows={data ?? []} columns={columns} disableRowSelectionOnClick />
+      </Box>
+    </Stack>
   )
 }
 

--- a/dancestudio/backend/app/api/routes/settings.py
+++ b/dancestudio/backend/app/api/routes/settings.py
@@ -1,28 +1,60 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, Request
 from sqlalchemy.orm import Session
 
 from ...api import deps
-from ...db import schemas
+from ...db import models, schemas
 from ...db.session import get_db
 from ...services import settings_service
 
 router = APIRouter(prefix="/settings", tags=["settings"])
 
 
+def _media_response(request: Request, asset: models.SettingMedia) -> schemas.SettingMedia:
+    url = request.url_for("media", path=asset.file_path)
+    return schemas.SettingMedia(
+        id=asset.id,
+        url=str(url),
+        media_type=asset.media_type.value,
+        filename=asset.file_name,
+    )
+
+
 @router.get("/addresses", response_model=schemas.StudioAddresses)
 def get_addresses(
+    request: Request,
     db: Session = Depends(get_db),
     _: None = Depends(deps.require_roles("admin", "manager")),
 ) -> schemas.StudioAddresses:
-    addresses = settings_service.get_addresses(db)
-    return schemas.StudioAddresses(addresses=addresses)
+    addresses, media_items = settings_service.get_addresses(db)
+    media = [_media_response(request, asset) for asset in media_items]
+    return schemas.StudioAddresses(addresses=addresses, media=media)
 
 
 @router.put("/addresses", response_model=schemas.StudioAddresses)
 def update_addresses(
+    request: Request,
     payload: schemas.StudioAddressesUpdate,
     db: Session = Depends(get_db),
     _: None = Depends(deps.require_roles("admin", "manager")),
 ) -> schemas.StudioAddresses:
-    addresses = settings_service.update_addresses(db, addresses=payload.addresses)
-    return schemas.StudioAddresses(addresses=addresses)
+    addresses, media_items = settings_service.update_addresses(
+        db,
+        addresses=payload.addresses,
+        media_ids=payload.media_ids,
+    )
+    media = [_media_response(request, asset) for asset in media_items]
+    return schemas.StudioAddresses(addresses=addresses, media=media)
+
+
+@router.post("/addresses/media", response_model=list[schemas.SettingMedia])
+async def upload_addresses_media(
+    request: Request,
+    files: list[UploadFile] = File(...),
+    db: Session = Depends(get_db),
+    _: None = Depends(deps.require_roles("admin", "manager")),
+) -> list[schemas.SettingMedia]:
+    try:
+        assets = settings_service.save_addresses_media(db, files)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return [_media_response(request, asset) for asset in assets]

--- a/dancestudio/backend/app/api/routes/users.py
+++ b/dancestudio/backend/app/api/routes/users.py
@@ -1,8 +1,9 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 from ...api import deps
 from ...db.session import get_db
 from ...db import models, schemas
+from ...services import subscription_service
 
 router = APIRouter(prefix="/users", tags=["users"])
 
@@ -13,6 +14,24 @@ def list_users(
     _: models.AdminUser = Depends(deps.require_roles("admin", "manager", "viewer")),
 ):
     return db.query(models.User).all()
+
+
+@router.get("/search", response_model=list[schemas.User])
+def search_users(
+    q: str = Query(..., min_length=2, description="Часть ФИО"),
+    limit: int = Query(10, ge=1, le=50),
+    db: Session = Depends(get_db),
+    _: models.AdminUser = Depends(deps.require_roles("admin", "manager", "viewer")),
+):
+    pattern = f"%{q.strip()}%"
+    results = (
+        db.query(models.User)
+        .filter(models.User.full_name.ilike(pattern))
+        .order_by(models.User.full_name.asc())
+        .limit(limit)
+        .all()
+    )
+    return results
 
 
 @router.get("/{user_id}", response_model=schemas.User)
@@ -42,3 +61,22 @@ def update_user(
     db.commit()
     db.refresh(user)
     return user
+
+
+@router.post("/{user_id}/manual-subscription", response_model=schemas.Subscription)
+def grant_manual_subscription(
+    user_id: int,
+    payload: schemas.ManualSubscriptionGrant,
+    db: Session = Depends(get_db),
+    _: models.AdminUser = Depends(deps.require_roles("admin", "manager")),
+):
+    user = db.get(models.User, user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    subscription = subscription_service.issue_manual_subscription(
+        db,
+        user_id=user.id,
+        classes_count=payload.classes_count,
+        validity_days=payload.validity_days,
+    )
+    return schemas.Subscription.model_validate(subscription)

--- a/dancestudio/backend/app/db/migrations/versions/0006_add_setting_media_and_manual_subscription.py
+++ b/dancestudio/backend/app/db/migrations/versions/0006_add_setting_media_and_manual_subscription.py
@@ -1,0 +1,50 @@
+"""Add setting media table and subscription initial classes
+
+Revision ID: 0006_add_setting_media_and_manual_subscription
+Revises: 0005_extend_payment_provider
+Create Date: 2025-10-07
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0006_add_setting_media_and_manual_subscription"
+down_revision = "0005_extend_payment_provider"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    media_type_enum = sa.Enum("image", "video", name="settingmediatype")
+    media_type_enum.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "setting_media",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("setting_key", sa.String(length=64), nullable=False),
+        sa.Column("file_path", sa.String(length=255), nullable=False),
+        sa.Column("file_name", sa.String(length=255), nullable=False),
+        sa.Column("content_type", sa.String(length=128), nullable=False),
+        sa.Column("media_type", media_type_enum, nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["setting_key"], ["settings.key"], ondelete="CASCADE"),
+    )
+
+    op.add_column(
+        "subscriptions",
+        sa.Column("initial_classes", sa.Integer(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("subscriptions", "initial_classes")
+    op.drop_table("setting_media")
+
+    media_type_enum = sa.Enum(name="settingmediatype")
+    media_type_enum.drop(op.get_bind(), checkfirst=True)

--- a/dancestudio/backend/app/db/models/__init__.py
+++ b/dancestudio/backend/app/db/models/__init__.py
@@ -9,3 +9,4 @@ from .waitlist import Waitlist, WaitlistStatus
 from .admin_user import AdminUser, AdminRole
 from .audit_log import AuditLog, ActorType
 from .setting import Setting
+from .setting_media import SettingMedia, SettingMediaType

--- a/dancestudio/backend/app/db/models/setting.py
+++ b/dancestudio/backend/app/db/models/setting.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 
 from sqlalchemy import DateTime, String, Text, func
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from ..session import Base
 
@@ -18,4 +18,10 @@ class Setting(Base):
         server_default=func.now(),
         onupdate=func.now(),
         nullable=False,
+    )
+    media = relationship(
+        "SettingMedia",
+        cascade="all, delete-orphan",
+        back_populates="setting",
+        lazy="selectin",
     )

--- a/dancestudio/backend/app/db/models/setting_media.py
+++ b/dancestudio/backend/app/db/models/setting_media.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum as PyEnum
+from pathlib import Path
+
+from sqlalchemy import DateTime, Enum, ForeignKey, Integer, String, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from ..session import Base
+
+
+class SettingMediaType(str, PyEnum):
+    image = "image"
+    video = "video"
+
+
+class SettingMedia(Base):
+    __tablename__ = "setting_media"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    setting_key: Mapped[str] = mapped_column(
+        String(64), ForeignKey("settings.key", ondelete="CASCADE"), nullable=False
+    )
+    file_path: Mapped[str] = mapped_column(String(255), nullable=False)
+    file_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    content_type: Mapped[str] = mapped_column(String(128), nullable=False)
+    media_type: Mapped[SettingMediaType] = mapped_column(Enum(SettingMediaType), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    setting = relationship("Setting", back_populates="media", lazy="joined")
+
+    @property
+    def path(self) -> Path:
+        return Path(self.file_path)

--- a/dancestudio/backend/app/db/models/subscription.py
+++ b/dancestudio/backend/app/db/models/subscription.py
@@ -18,6 +18,7 @@ class Subscription(Base):
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), index=True)
     product_id: Mapped[int] = mapped_column(ForeignKey("products.id"))
     remaining_classes: Mapped[int] = mapped_column(Integer, default=0)
+    initial_classes: Mapped[int | None] = mapped_column(Integer, nullable=True)
     valid_from: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     valid_to: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     status: Mapped[SubscriptionStatus] = mapped_column(Enum(SubscriptionStatus), default=SubscriptionStatus.active)

--- a/dancestudio/backend/app/db/schemas/__init__.py
+++ b/dancestudio/backend/app/db/schemas/__init__.py
@@ -4,4 +4,5 @@ from .product import Product, ProductCreate, ProductUpdate
 from .booking import Booking, BookingCreate, BookingCancel
 from .payment import Payment, PaymentCreate, PaymentWebhook
 from .user import User, UserUpdate
-from .setting import StudioAddresses, StudioAddressesUpdate
+from .setting import StudioAddresses, StudioAddressesUpdate, SettingMedia
+from .subscription import ManualSubscriptionGrant, Subscription

--- a/dancestudio/backend/app/db/schemas/setting.py
+++ b/dancestudio/backend/app/db/schemas/setting.py
@@ -1,11 +1,20 @@
 from __future__ import annotations
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+
+class SettingMedia(BaseModel):
+    id: int
+    url: str
+    media_type: str
+    filename: str
 
 
 class StudioAddresses(BaseModel):
     addresses: str
+    media: list[SettingMedia] = Field(default_factory=list)
 
 
 class StudioAddressesUpdate(BaseModel):
     addresses: str
+    media_ids: list[int] = Field(default_factory=list)

--- a/dancestudio/backend/app/db/schemas/subscription.py
+++ b/dancestudio/backend/app/db/schemas/subscription.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class ManualSubscriptionGrant(BaseModel):
+    classes_count: int = Field(gt=0, description="Количество занятий для абонемента")
+    validity_days: int | None = Field(
+        default=None,
+        gt=0,
+        description="Срок действия в днях. Если не указан, используется значение по умолчанию.",
+    )
+
+
+class Subscription(BaseModel):
+    id: int
+    user_id: int
+    product_id: int
+    remaining_classes: int
+    initial_classes: int | None = None
+    valid_from: datetime
+    valid_to: datetime
+    status: str
+
+    class Config:
+        from_attributes = True

--- a/dancestudio/backend/app/main.py
+++ b/dancestudio/backend/app/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
 from .api.routes import (
     auth,
     directions,
@@ -15,6 +16,7 @@ from .api.routes import (
 from .db.session import Base, engine, SessionLocal
 from .config import get_settings
 from .services.admin import ensure_admin_exists
+from .services.storage import BASE_MEDIA_DIR, ensure_media_directory
 
 
 app = FastAPI(title="DanceStudioBot API", version="1.0.0")
@@ -37,6 +39,9 @@ app.include_router(users.router, prefix="/api/v1")
 app.include_router(misc.router, prefix="/api/v1")
 app.include_router(bot.router, prefix="/api/v1")
 app.include_router(settings.router, prefix="/api/v1")
+
+ensure_media_directory()
+app.mount("/media", StaticFiles(directory=BASE_MEDIA_DIR), name="media")
 
 
 @app.on_event("startup")

--- a/dancestudio/backend/app/services/settings_service.py
+++ b/dancestudio/backend/app/services/settings_service.py
@@ -1,24 +1,102 @@
 from __future__ import annotations
 
+from pathlib import Path
+from typing import Iterable
+
+from fastapi import UploadFile
 from sqlalchemy.orm import Session
 
 from ..db import models
+from ..db.models.setting_media import SettingMediaType
+from .storage import (
+    ensure_media_directory,
+    get_media_path,
+    relative_media_path,
+    remove_media_file,
+)
 
 ADDRESSES_KEY = "studio_addresses"
+_MEDIA_SUBDIR = Path("settings") / "addresses"
 
 
-def get_addresses(db: Session) -> str:
+def get_addresses(db: Session) -> tuple[str, list[models.SettingMedia]]:
     setting = db.get(models.Setting, ADDRESSES_KEY)
-    return setting.value if setting and setting.value is not None else ""
+    addresses = setting.value if setting and setting.value is not None else ""
+    media_items = (
+        db.query(models.SettingMedia)
+        .filter(models.SettingMedia.setting_key == ADDRESSES_KEY)
+        .order_by(models.SettingMedia.created_at.asc())
+        .all()
+    )
+    return addresses, media_items
 
 
-def update_addresses(db: Session, *, addresses: str) -> str:
+def _guess_media_type(upload: UploadFile) -> SettingMediaType:
+    content_type = (upload.content_type or "").lower()
+    if content_type.startswith("image/"):
+        return SettingMediaType.image
+    if content_type.startswith("video/"):
+        return SettingMediaType.video
+    raise ValueError("Unsupported media type")
+
+
+def save_addresses_media(db: Session, files: Iterable[UploadFile]) -> list[models.SettingMedia]:
+    ensure_media_directory(_MEDIA_SUBDIR)
+    created: list[models.SettingMedia] = []
+    for upload in files:
+        data = upload.file.read()
+        if not data:
+            continue
+        media_type = _guess_media_type(upload)
+        target_path = get_media_path(_MEDIA_SUBDIR, upload.filename)
+        target_path.write_bytes(data)
+        relative_path = relative_media_path(target_path)
+        asset = models.SettingMedia(
+            setting_key=ADDRESSES_KEY,
+            file_path=relative_path,
+            file_name=upload.filename or target_path.name,
+            content_type=upload.content_type or "application/octet-stream",
+            media_type=media_type,
+        )
+        db.add(asset)
+        created.append(asset)
+    if created:
+        db.commit()
+        for asset in created:
+            db.refresh(asset)
+    return created
+
+
+def update_addresses(
+    db: Session,
+    *,
+    addresses: str,
+    media_ids: Iterable[int] | None = None,
+) -> tuple[str, list[models.SettingMedia]]:
     value = addresses.strip()
     setting = db.get(models.Setting, ADDRESSES_KEY)
     if not setting:
         setting = models.Setting(key=ADDRESSES_KEY)
         db.add(setting)
     setting.value = value
+    keep_ids = {int(media_id) for media_id in (media_ids or [])}
+    existing = (
+        db.query(models.SettingMedia)
+        .filter(models.SettingMedia.setting_key == ADDRESSES_KEY)
+        .all()
+    )
+    for asset in existing:
+        if asset.id not in keep_ids:
+            remove_media_file(asset.file_path)
+            db.delete(asset)
     db.commit()
     db.refresh(setting)
-    return setting.value or ""
+    return get_addresses(db)
+
+
+__all__ = [
+    "ADDRESSES_KEY",
+    "get_addresses",
+    "save_addresses_media",
+    "update_addresses",
+]

--- a/dancestudio/backend/app/services/storage.py
+++ b/dancestudio/backend/app/services/storage.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import uuid4
+
+BASE_MEDIA_DIR = Path(__file__).resolve().parents[1] / "media"
+
+
+def ensure_media_directory(subdir: Path | str | None = None) -> Path:
+    base = BASE_MEDIA_DIR
+    if subdir:
+        base = base / Path(subdir)
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def get_media_path(subdir: Path | str | None, original_name: str | None = None) -> Path:
+    directory = ensure_media_directory(subdir)
+    suffix = ""
+    if original_name:
+        suffix = Path(original_name).suffix
+    filename = f"{uuid4().hex}{suffix}"
+    return directory / filename
+
+
+def remove_media_file(relative_path: str) -> None:
+    path = BASE_MEDIA_DIR / Path(relative_path)
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return
+    except OSError:
+        return
+
+
+def relative_media_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(BASE_MEDIA_DIR))
+    except ValueError:
+        return str(path)


### PR DESCRIPTION
## Summary
- require Telegram bot users to confirm full name and age when booking, persisting and reusing prior answers
- add admin tooling to search dancers by FIO and grant manual subscriptions for any number of classes
- enable uploading multiple photos and videos for studio addresses and expose media via the API

## Testing
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e3fb207ae483298370313297917b9b