### PR TITLE
Prevent duplicate enum creation in setting media migration

### DIFF
--- a/dancestudio/backend/app/db/migrations/versions/0006_add_setting_media_and_manual_subscription.py
+++ b/dancestudio/backend/app/db/migrations/versions/0006_add_setting_media_and_manual_subscription.py
@@ -26,7 +26,16 @@ def upgrade() -> None:
         sa.Column("file_path", sa.String(length=255), nullable=False),
         sa.Column("file_name", sa.String(length=255), nullable=False),
         sa.Column("content_type", sa.String(length=128), nullable=False),
-        sa.Column("media_type", media_type_enum, nullable=False),
+        sa.Column(
+            "media_type",
+            sa.Enum(
+                "image",
+                "video",
+                name="settingmediatype",
+                create_type=False,
+            ),
+            nullable=False,
+        ),
         sa.Column(
             "created_at",
             sa.DateTime(timezone=True),


### PR DESCRIPTION
## Summary
- ensure the setting media migration reuses the existing settingmediatype enum instead of recreating it

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e409af653c8329b81409ae3ec5bdb6