### PR TITLE
Handle existing setting media enum in migration

### DIFF
--- a/dancestudio/backend/app/db/migrations/versions/0006_add_setting_media_and_manual_subscription.py
+++ b/dancestudio/backend/app/db/migrations/versions/0006_add_setting_media_and_manual_subscription.py
@@ -17,10 +17,19 @@ depends_on = None
 
 
 def upgrade() -> None:
-    media_type_enum = postgresql.ENUM(
-        "image", "video", name="settingmediatype", create_type=True
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_type WHERE typname = 'settingmediatype'
+            ) THEN
+                CREATE TYPE settingmediatype AS ENUM ('image', 'video');
+            END IF;
+        END
+        $$;
+        """
     )
-    media_type_enum.create(op.get_bind(), checkfirst=True)
 
     op.create_table(
         "setting_media",


### PR DESCRIPTION
## Summary
- guard the `settingmediatype` enum creation with a DO block that checks for the existing type
- keep the migration using the shared enum when creating the `setting_media` table

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e40ed914508329941beb108e8d5f1b