### PR TITLE
Fix enum creation in setting media migration

### DIFF
--- a/dancestudio/backend/app/db/migrations/versions/0006_add_setting_media_and_manual_subscription.py
+++ b/dancestudio/backend/app/db/migrations/versions/0006_add_setting_media_and_manual_subscription.py
@@ -16,20 +16,11 @@ branch_labels = None
 depends_on = None
 
 
+media_type_enum = postgresql.ENUM("image", "video", name="settingmediatype")
+
+
 def upgrade() -> None:
-    op.execute(
-        """
-        DO $$
-        BEGIN
-            IF NOT EXISTS (
-                SELECT 1 FROM pg_type WHERE typname = 'settingmediatype'
-            ) THEN
-                CREATE TYPE settingmediatype AS ENUM ('image', 'video');
-            END IF;
-        END
-        $$;
-        """
-    )
+    media_type_enum.create(op.get_bind(), checkfirst=True)
 
     op.create_table(
         "setting_media",
@@ -40,12 +31,7 @@ def upgrade() -> None:
         sa.Column("content_type", sa.String(length=128), nullable=False),
         sa.Column(
             "media_type",
-            postgresql.ENUM(
-                "image",
-                "video",
-                name="settingmediatype",
-                create_type=False,
-            ),
+            media_type_enum,
             nullable=False,
         ),
         sa.Column(
@@ -67,5 +53,4 @@ def downgrade() -> None:
     op.drop_column("subscriptions", "initial_classes")
     op.drop_table("setting_media")
 
-    media_type_enum = postgresql.ENUM(name="settingmediatype")
     media_type_enum.drop(op.get_bind(), checkfirst=True)


### PR DESCRIPTION
## Summary
- define the PostgreSQL enum once at module scope for the setting media migration
- create the enum with `checkfirst=True` and reuse it for the column to avoid duplicate type creation errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e410e0ba8883299cd773bd5a63fe01