### PR TITLE
Fix Alembic revision identifier length

### DIFF
--- a/dancestudio/backend/app/db/migrations/versions/0006_setting_media_manual.py
+++ b/dancestudio/backend/app/db/migrations/versions/0006_setting_media_manual.py
@@ -1,6 +1,6 @@
 """Add setting media table and subscription initial classes
 
-Revision ID: 0006_add_setting_media_and_manual_subscription
+Revision ID: 0006_setting_media_manual
 Revises: 0005_extend_payment_provider
 Create Date: 2025-10-07
 """
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
-revision = "0006_add_setting_media_and_manual_subscription"
+revision = "0006_setting_media_manual"
 down_revision = "0005_extend_payment_provider"
 branch_labels = None
 depends_on = None


### PR DESCRIPTION
## Summary
- rename the 0006 Alembic migration to use a shorter revision identifier that fits the alembic_version column
- update the migration metadata to reference the shortened revision id

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e4149bd9b883299888e335caf51a67