### PR TITLE
Fix Alembic script location resolution

### DIFF
--- a/dancestudio/backend/alembic.ini
+++ b/dancestudio/backend/alembic.ini
@@ -1,5 +1,5 @@
 [alembic]
-script_location = app/db/migrations
+script_location = %(here)s/app/db/migrations
 sqlalchemy.url = postgresql+psycopg2://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
 
 [loggers]

--- a/dancestudio/deploy/docker-compose.yml
+++ b/dancestudio/deploy/docker-compose.yml
@@ -33,7 +33,7 @@ services:
         condition: service_healthy
       redis:
         condition: service_started
-    command: /bin/bash -c "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000"
+    command: /bin/bash -c "alembic -c /app/alembic.ini upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000"
     ports:
       - "8000:8000"
 


### PR DESCRIPTION
## Summary
- make the Alembic script location relative to the configuration file so migrations load reliably
- run Alembic in Docker Compose with an explicit config path before starting the API server

## Testing
- alembic -c dancestudio/backend/alembic.ini heads

------
https://chatgpt.com/codex/tasks/task_e_68e4162e46808329834d378621eb3cd2