### PR TITLE
Fix nginx static asset volume sharing

### DIFF
--- a/dancestudio/deploy/docker-compose.yml
+++ b/dancestudio/deploy/docker-compose.yml
@@ -58,12 +58,14 @@ services:
         condition: service_started
     ports:
       - "5173:5173"
+    volumes:
+      - frontend_dist:/app/dist
 
   nginx:
     image: nginx:1.25
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
-      - ../admin-frontend/dist:/usr/share/nginx/html:ro
+      - frontend_dist:/usr/share/nginx/html:ro
     ports:
       - "80:80"
     depends_on:
@@ -72,3 +74,4 @@ services:
 
 volumes:
   postgres_data:
+  frontend_dist:


### PR DESCRIPTION
## Summary
- share the built admin frontend "dist" directory with nginx using a named volume
- avoid mounting a potentially empty host directory that caused nginx to loop on /index.html

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4d9d9fa608329aaf7bcb80d7ccd29