### PR TITLE
Add media download for studio addresses

### DIFF
--- a/dancestudio/bot/services/__init__.py
+++ b/dancestudio/bot/services/__init__.py
@@ -9,6 +9,7 @@ from .api_client import (
     create_subscription_payment,
     sync_user,
     fetch_studio_addresses,
+    download_media,
 )
 
 __all__ = [
@@ -22,4 +23,5 @@ __all__ = [
     "create_subscription_payment",
     "sync_user",
     "fetch_studio_addresses",
+    "download_media",
 ]

--- a/dancestudio/bot/services/api_client.py
+++ b/dancestudio/bot/services/api_client.py
@@ -250,6 +250,15 @@ async def fetch_studio_addresses() -> StudioAddresses:
     return result
 
 
+async def download_media(path: str) -> bytes:
+    async with httpx.AsyncClient(
+        base_url=_settings.api_base_url, timeout=10.0
+    ) as client:
+        response = await client.get(_request_path(path), headers=_headers())
+        response.raise_for_status()
+        return response.content
+
+
 __all__ = [
     "Product",
     "Direction",
@@ -270,4 +279,5 @@ __all__ = [
     "create_subscription_payment",
     "confirm_payment",
     "fetch_studio_addresses",
+    "download_media",
 ]


### PR DESCRIPTION
## Summary
- download studio address media from the API before sending to Telegram
- expose a reusable helper for downloading media assets used by the bot
- attach the downloaded files when the user opens the addresses section

## Testing
- pytest dancestudio/bot/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68e4e4658fb08329b07909471d795c7a